### PR TITLE
Updating release of provider continues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,5 +20,6 @@ jobs:
     uses: hashicorp/ghaction-terraform-provider-release/.github/workflows/community.yml@v2
     secrets:
       gpg-private-key: '${{ secrets.GPG_PRIVATE_KEY }}'
+      gpg-private-key-passphrase: ${{ secrets.PASSPHRASE }}
     with:
       setup-go-version-file: 'go.mod'


### PR DESCRIPTION
we need to use our passphrase to get past `gpg: signing failed: Inappropriate ioctl for device`