### PR TITLE
Fix read functions to set resource based on response

### DIFF
--- a/synthetics/resource_api_check_v2.go
+++ b/synthetics/resource_api_check_v2.go
@@ -205,12 +205,15 @@ func resourceApiCheckV2Read(ctx context.Context, d *schema.ResourceData, meta in
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
 	o, _, err := c.GetApiCheckV2(checkID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	log.Println("[DEBUG] GET REQUEST BODY JSON: ", o)
+	apiCheck := flattenApiV2Read(o)
+	if err := d.Set("test", apiCheck); err != nil {
+		return diag.FromErr(err)
+	}
 
 	return diags
 }
@@ -249,7 +252,6 @@ func resourceApiCheckV2Update(ctx context.Context, d *schema.ResourceData, meta 
 	if err != nil {
 		return diag.FromErr(err)
 	}
-
 	o, _, err := c.UpdateApiCheckV2(checkIdString, &checkData)
 	if err != nil {
 		return diag.FromErr(err)
@@ -262,7 +264,6 @@ func resourceApiCheckV2Update(ctx context.Context, d *schema.ResourceData, meta 
 }
 
 func processApiCheckV2Items(d *schema.ResourceData) sc2.ApiCheckV2Input {
-
 	var check = buildApiV2Data(d)
 
 	log.Println("[DEBUG] API V2 CHECK OUTPUT: ", check)

--- a/synthetics/resource_api_check_v2.go
+++ b/synthetics/resource_api_check_v2.go
@@ -210,8 +210,7 @@ func resourceApiCheckV2Read(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.FromErr(err)
 	}
 	log.Println("[DEBUG] GET REQUEST BODY JSON: ", o)
-	apiCheck := flattenApiV2Read(o)
-	if err := d.Set("test", apiCheck); err != nil {
+	if err := d.Set("test", flattenApiV2Read(o)); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/synthetics/resource_browser_check_v2.go
+++ b/synthetics/resource_browser_check_v2.go
@@ -295,6 +295,9 @@ func resourceBrowserCheckV2Read(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 	log.Println("[DEBUG] GET BROWSER BODY: ", o)
+	if err := d.Set("test", flattenBrowserV2Read(o)); err != nil {
+		return diag.FromErr(err)
+	}
 
 	return diags
 }

--- a/synthetics/resource_http_check_v2.go
+++ b/synthetics/resource_http_check_v2.go
@@ -145,8 +145,7 @@ func resourceHttpCheckV2Read(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 	log.Println("[DEBUG] GET HTTP BODY: ", o)
-	httpCheck:= flattenHttpV2Read(o)
-	if err := d.Set("test", httpCheck); err != nil {
+	if err := d.Set("test", flattenHttpV2Read(o)); err != nil {
 		return diag.FromErr(err)
 	}
 

--- a/synthetics/resource_http_check_v2.go
+++ b/synthetics/resource_http_check_v2.go
@@ -145,6 +145,10 @@ func resourceHttpCheckV2Read(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 	log.Println("[DEBUG] GET HTTP BODY: ", o)
+	httpCheck:= flattenHttpV2Read(o)
+	if err := d.Set("test", httpCheck); err != nil {
+		return diag.FromErr(err)
+	}
 
 	return diags
 }

--- a/synthetics/resource_location_v2.go
+++ b/synthetics/resource_location_v2.go
@@ -109,6 +109,9 @@ func resourceLocationV2Read(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.FromErr(err)
 	}
 	log.Println("DEBUG] GET location response data: ", location)
+	if err := d.Set("location", flattenLocationV2Data(location.Location)); err != nil {
+		return diag.FromErr(err)
+	}
 
 	return diags
 }

--- a/synthetics/resource_port_check_v2.go
+++ b/synthetics/resource_port_check_v2.go
@@ -134,6 +134,9 @@ func resourcePortCheckV2Read(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 	log.Println("[DEBUG] GET PORT BODY: ", o)
+	if err := d.Set("test", flattenPortCheckV2Read(o)); err != nil {
+		return diag.FromErr(err)
+	}
 
 	return diags
 }

--- a/synthetics/resource_variable_v2.go
+++ b/synthetics/resource_variable_v2.go
@@ -103,6 +103,9 @@ func resourceVariableV2Read(ctx context.Context, d *schema.ResourceData, meta in
 		return diag.FromErr(err)
 	}
 	log.Println("DEBUG] GET variable response data: ", variable)
+	if err := d.Set("variable", flattenVariableV2Read(variable)); err != nil {
+		return diag.FromErr(err)
+	}
 
 	return diags
 }

--- a/synthetics/structures.go
+++ b/synthetics/structures.go
@@ -44,6 +44,37 @@ func flattenStringIdData(test interface{}) string {
 	return id.(string)
 }
 
+func flattenApiV2Read(checkApiV2 *sc2.ApiCheckV2Response) []interface{} {
+	apiV2 := make(map[string]interface{})
+
+	apiV2["active"] = checkApiV2.Test.Active
+
+	if checkApiV2.Test.Frequency != 0 {
+		apiV2["frequency"] = checkApiV2.Test.Frequency
+	}
+
+	if checkApiV2.Test.Name != "" {
+		apiV2["name"] = checkApiV2.Test.Name
+	}
+
+	if checkApiV2.Test.Schedulingstrategy != "" {
+		apiV2["scheduling_strategy"] = checkApiV2.Test.Schedulingstrategy
+	}
+
+	apiV2["device_id"] = checkApiV2.Test.Device.ID
+	
+
+	locationIds := flattenLocationData(&checkApiV2.Test.Locationids)
+	apiV2["location_ids"] = locationIds
+
+	requests := flattenRequestData(&checkApiV2.Test.Requests)
+	apiV2["requests"] = requests
+
+	log.Println("[DEBUG] apiv2 data: ", apiV2)
+
+	return []interface{}{apiV2}
+}
+
 func flattenApiV2Data(checkApiV2 *sc2.ApiCheckV2Response) []interface{} {
 	apiV2 := make(map[string]interface{})
 
@@ -300,6 +331,51 @@ func flattenBrowserV2Data(checkBrowserV2 *sc2.BrowserCheckV2Response) []interfac
 	log.Println("[DEBUG] browserv2 data: ", browserV2)
 
 	return []interface{}{browserV2}
+}
+
+func flattenHttpV2Read(checkHttpV2 *sc2.HttpCheckV2Response) []interface{} {
+	httpV2 := make(map[string]interface{})
+
+
+	if checkHttpV2.Test.Name != "" {
+		httpV2["name"] = checkHttpV2.Test.Name
+	}
+
+	httpV2["active"] = checkHttpV2.Test.Active
+
+	if checkHttpV2.Test.Frequency != 0 {
+		httpV2["frequency"] = checkHttpV2.Test.Frequency
+	}
+
+	if checkHttpV2.Test.SchedulingStrategy != "" {
+		httpV2["scheduling_strategy"] = checkHttpV2.Test.SchedulingStrategy
+	}
+
+	if checkHttpV2.Test.Type != "" {
+		httpV2["type"] = checkHttpV2.Test.Type
+	}
+
+	if checkHttpV2.Test.URL != "" {
+		httpV2["url"] = checkHttpV2.Test.URL
+	}
+
+	if checkHttpV2.Test.RequestMethod != "" {
+		httpV2["request_method"] = checkHttpV2.Test.RequestMethod
+	}
+
+	if checkHttpV2.Test.Body != "" {
+		httpV2["body"] = checkHttpV2.Test.Body
+	}
+
+	locationIds := flattenLocationData(&checkHttpV2.Test.LocationIds)
+	httpV2["location_ids"] = locationIds
+
+	httpHeaders := flattenHttpHeadersData(&checkHttpV2.Test.HttpHeaders)
+	httpV2["headers"] = httpHeaders
+
+	log.Println("[DEBUG] httpV2 data: ", httpV2)
+
+	return []interface{}{httpV2}
 }
 
 func flattenHttpV2Data(checkHttpV2 *sc2.HttpCheckV2Response) []interface{} {

--- a/synthetics/structures.go
+++ b/synthetics/structures.go
@@ -124,6 +124,22 @@ func flattenApiV2Data(checkApiV2 *sc2.ApiCheckV2Response) []interface{} {
 	return []interface{}{apiV2}
 }
 
+func flattenVariableV2Read(checkVariableV2 *sc2.VariableV2Response) []interface{} {
+	variableV2 := make(map[string]interface{})
+
+	variableV2["name"] = checkVariableV2.Variable.Name
+
+	variableV2["description"] = checkVariableV2.Variable.Description
+
+	variableV2["value"] = checkVariableV2.Variable.Value
+
+	variableV2["secret"] = checkVariableV2.Variable.Secret
+
+	log.Println("[DEBUG] VARIABLE V2 data: ", variableV2)
+
+	return []interface{}{variableV2}
+}
+
 func flattenVariableV2Data(checkVariableV2 *sc2.VariableV2Response) []interface{} {
 	variableV2 := make(map[string]interface{})
 
@@ -276,6 +292,44 @@ func flattenLocationMetaV2Data(checkLocationV2 sc2.Meta) []interface{} {
 	log.Println("[DEBUG] Location Meta V2 data: ", locationMetaV2)
 
 	return []interface{}{locationMetaV2}
+}
+func flattenBrowserV2Read(checkBrowserV2 *sc2.BrowserCheckV2Response) []interface{} {
+	browserV2 := make(map[string]interface{})
+
+	browserV2["active"] = checkBrowserV2.Test.Active
+
+	browserV2["device_id"] = checkBrowserV2.Test.Device.ID
+
+	if checkBrowserV2.Test.Frequency != 0 {
+		browserV2["frequency"] = checkBrowserV2.Test.Frequency
+	}
+
+	if checkBrowserV2.Test.Name != "" {
+		browserV2["name"] = checkBrowserV2.Test.Name
+	}
+
+	if checkBrowserV2.Test.Schedulingstrategy != "" {
+		browserV2["scheduling_strategy"] = checkBrowserV2.Test.Schedulingstrategy
+	}
+
+	if checkBrowserV2.Test.Type != "" {
+		browserV2["type"] = checkBrowserV2.Test.Type
+	}
+
+	browserV2["start_url"] = checkBrowserV2.Test.Transactions[0].StepsV2[0].URL
+
+	locationIds := flattenLocationData(&checkBrowserV2.Test.Locationids)
+	browserV2["location_ids"] = locationIds
+
+	advancedSettings := flattenAdvancedSettingsData(&checkBrowserV2.Test.Advancedsettings)
+	browserV2["advanced_settings"] = advancedSettings
+
+	transactions := flattenTransactionsData(&checkBrowserV2.Test.Transactions)
+	browserV2["transactions"] = transactions
+
+	log.Println("[DEBUG] browserv2 data: ", browserV2)
+
+	return []interface{}{browserV2}
 }
 
 func flattenBrowserV2Data(checkBrowserV2 *sc2.BrowserCheckV2Response) []interface{} {
@@ -434,6 +488,47 @@ func flattenHttpV2Data(checkHttpV2 *sc2.HttpCheckV2Response) []interface{} {
 	log.Println("[DEBUG] httpV2 data: ", httpV2)
 
 	return []interface{}{httpV2}
+}
+
+func flattenPortCheckV2Read(checkPortV2 *sc2.PortCheckV2Response) []interface{} {
+	portV2 := make(map[string]interface{})
+
+	if checkPortV2.Test.Name != "" {
+		portV2["name"] = checkPortV2.Test.Name
+	}
+
+	portV2["active"] = checkPortV2.Test.Active
+
+	if checkPortV2.Test.Frequency != 0 {
+		portV2["frequency"] = checkPortV2.Test.Frequency
+	}
+
+	if checkPortV2.Test.SchedulingStrategy != "" {
+		portV2["scheduling_strategy"] = checkPortV2.Test.SchedulingStrategy
+	}
+
+	if checkPortV2.Test.Type != "" {
+		portV2["type"] = checkPortV2.Test.Type
+	}
+
+	if checkPortV2.Test.Protocol != "" {
+		portV2["protocol"] = checkPortV2.Test.Protocol
+	}
+
+	if checkPortV2.Test.Host != "" {
+		portV2["host"] = checkPortV2.Test.Host
+	}
+
+	if checkPortV2.Test.Port != 0 {
+		portV2["port"] = checkPortV2.Test.Port
+	}
+
+	locationIds := flattenLocationData(&checkPortV2.Test.LocationIds)
+	portV2["location_ids"] = locationIds
+
+	log.Println("[DEBUG] portv2 data: ", portV2)
+
+	return []interface{}{portV2}
 }
 
 func flattenPortCheckV2Data(checkPortV2 *sc2.PortCheckV2Response) []interface{} {


### PR DESCRIPTION
The PR is to fix the read functions of all the resources so that fields obtained from the API call are set to the resource state. 

New corresponding flatten functions are added as the data sources and resources have different schemas. 