### PR TITLE
Fix for Api validation/setup/request ordering

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,7 +3,7 @@ HOSTNAME=github.com
 NAMESPACE=splunk
 NAME=synthetics
 BINARY=terraform-provider-${NAME}
-VERSION=2.0.1
+VERSION=2.0.2
 
 default: install
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ description: |-
 terraform {
   required_providers {
     synthetics = {
-      version = "2.0.1"
+      version = "2.0.2"
       source  = "splunk/synthetics"
     }
   }
@@ -37,4 +37,5 @@ provider "synthetics" {
 - `apikey` (String) Splunk Observability API Key. Will pull from `OBSERVABILITY_API_TOKEN` environment variable if available.
 - `product` (String) One of: `observability` or `rigor`
 - `realm` (String) Splunk Observability Realm (E.G. `us1`). Will pull from `REALM` environment variable if available. For Rigor use realm rigor
+
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,11 @@ provider "synthetics" {
 
 ### Required
 
+- `product` (String) One of: `observability` or `rigor`
+- `realm` (String) Splunk Observability Realm (E.G. `us1`). Will pull from `REALM` environment variable if available. For Rigor use realm rigor
+
+### Optional
+
 - `apikey` (String) Splunk Observability API Key. Will pull from `OBSERVABILITY_API_TOKEN` environment variable if available.
 - `product` (String) One of: `observability` or `rigor`
 - `realm` (String) Splunk Observability Realm (E.G. `us1`). Will pull from `REALM` environment variable if available. For Rigor use realm rigor

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,11 +34,7 @@ provider "synthetics" {
 
 ### Required
 
-- `product` (String) One of: `observability` or `rigor`
-- `realm` (String) Splunk Observability Realm (E.G. `us1`). Will pull from `REALM` environment variable if available. For Rigor use realm rigor
-
-### Optional
-
 - `apikey` (String) Splunk Observability API Key. Will pull from `OBSERVABILITY_API_TOKEN` environment variable if available.
 - `product` (String) One of: `observability` or `rigor`
 - `realm` (String) Splunk Observability Realm (E.G. `us1`). Will pull from `REALM` environment variable if available. For Rigor use realm rigor
+

--- a/docs/resources/create_api_check_v2.md
+++ b/docs/resources/create_api_check_v2.md
@@ -163,7 +163,7 @@ Required:
 
 Optional:
 
-- `requests` (Block Set) (see [below for nested schema](#nestedblock--test--requests))
+- `requests` (Block List) (see [below for nested schema](#nestedblock--test--requests))
 - `scheduling_strategy` (String)
 
 <a id="nestedblock--test--requests"></a>
@@ -171,9 +171,9 @@ Optional:
 
 Optional:
 
-- `configuration` (Block Set) (see [below for nested schema](#nestedblock--test--requests--configuration))
-- `setup` (Block Set) (see [below for nested schema](#nestedblock--test--requests--setup))
-- `validations` (Block Set) (see [below for nested schema](#nestedblock--test--requests--validations))
+- `configuration` (Block List) (see [below for nested schema](#nestedblock--test--requests--configuration))
+- `setup` (Block List) (see [below for nested schema](#nestedblock--test--requests--setup))
+- `validations` (Block List) (see [below for nested schema](#nestedblock--test--requests--validations))
 
 <a id="nestedblock--test--requests--configuration"></a>
 ### Nested Schema for `test.requests.configuration`

--- a/docs/resources/create_http_check_v2.md
+++ b/docs/resources/create_http_check_v2.md
@@ -69,7 +69,7 @@ Optional:
 - `scheduling_strategy` (String)
 - `type` (String)
 - `user_agent` (String)
-- `validations` (Block Set) (see [below for nested schema](#nestedblock--test--validations))
+- `validations` (Block List) (see [below for nested schema](#nestedblock--test--validations))
 
 Read-Only:
 

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     synthetics = {
-      version = "2.0.1"
+      version = "2.0.2"
       source  = "splunk/synthetics"
     }
   }

--- a/synthetics/resource_api_check_v2.go
+++ b/synthetics/resource_api_check_v2.go
@@ -65,12 +65,12 @@ func resourceApiCheckV2() *schema.Resource {
 							Required: true,
 						},
 						"requests": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Optional: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"configuration": {
-										Type:     schema.TypeSet,
+										Type:     schema.TypeList,
 										Optional: true,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
@@ -102,7 +102,7 @@ func resourceApiCheckV2() *schema.Resource {
 										},
 									},
 									"setup": {
-										Type:     schema.TypeSet,
+										Type:     schema.TypeList,
 										Optional: true,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
@@ -138,7 +138,7 @@ func resourceApiCheckV2() *schema.Resource {
 										},
 									},
 									"validations": {
-										Type:     schema.TypeSet,
+										Type:     schema.TypeList,
 										Optional: true,
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{

--- a/synthetics/resource_http_check_v2.go
+++ b/synthetics/resource_http_check_v2.go
@@ -121,7 +121,7 @@ func resourceHttpCheckV2() *schema.Resource {
 							},
 						},
 						"validations": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Optional: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{

--- a/synthetics/structures.go
+++ b/synthetics/structures.go
@@ -1084,7 +1084,7 @@ func buildApiV2Data(d *schema.ResourceData) sc2.ApiCheckV2Input {
 			apiv2.Test.Frequency = api["frequency"].(int)
 			apiv2.Test.Locationids = buildLocationIdData(api["location_ids"].([]interface{}))
 			apiv2.Test.Name = api["name"].(string)
-			apiv2.Test.Requests = buildRequestsData(api["requests"].(*schema.Set))
+			apiv2.Test.Requests = buildRequestsData(api["requests"].(([]interface{})))
 			apiv2.Test.Schedulingstrategy = api["scheduling_strategy"].(string)
 		}
 	}
@@ -1132,7 +1132,7 @@ func buildHttpV2Data(d *schema.ResourceData) sc2.HttpCheckV2Input {
 			userAgentString := http["user_agent"].(string)
 			httpv2.Test.UserAgent = &userAgentString
 			httpv2.Test.HttpHeaders = buildHttpHeadersData(http["headers"].(*schema.Set))
-			httpv2.Test.Validations = buildValidationsData(http["validations"].(*schema.Set))
+			httpv2.Test.Validations = buildValidationsData(http["validations"].([]interface{}))
 			i++
 		}
 	}
@@ -1191,15 +1191,14 @@ func buildLocationIdData(d []interface{}) []string {
 	return locationsList
 }
 
-func buildRequestsData(requests *schema.Set) []sc2.Requests {
-	requestsList := make([]sc2.Requests, len(requests.List()))
-
-	for i, request := range requests.List() {
+func buildRequestsData(requests []interface{}) []sc2.Requests {
+	requestsList := make([]sc2.Requests, len(requests))
+	for i, request := range requests {
 		request := request.(map[string]interface{})
 		req := sc2.Requests{
-			Configuration: buildConfigurationData(request["configuration"].(*schema.Set)),
-			Setup:         buildSetupData(request["setup"].(*schema.Set)),
-			Validations:   buildValidationsData(request["validations"].(*schema.Set)),
+			Configuration: buildConfigurationData(request["configuration"].([]interface{})),
+			Setup:         buildSetupData(request["setup"].([]interface{})),
+			Validations:   buildValidationsData(request["validations"].([]interface{})),
 		}
 		requestsList[i] = req
 
@@ -1262,10 +1261,10 @@ func buildStepV2Data(steps []interface{}) []sc2.StepsV2 {
 	return stepsList
 }
 
-func buildSetupData(setups *schema.Set) []sc2.Setup {
-	setupsList := make([]sc2.Setup, len(setups.List()))
+func buildSetupData(setups []interface{}) []sc2.Setup {
+	setupsList := make([]sc2.Setup, len(setups))
 
-	for i, setup := range setups.List() {
+	for i, setup := range setups {
 		setup := setup.(map[string]interface{})
 		set := sc2.Setup{
 			Extractor: setup["extractor"].(string),
@@ -1282,10 +1281,10 @@ func buildSetupData(setups *schema.Set) []sc2.Setup {
 	return setupsList
 }
 
-func buildValidationsData(validations *schema.Set) []sc2.Validations {
-	validationsList := make([]sc2.Validations, len(validations.List()))
+func buildValidationsData(validations []interface{}) []sc2.Validations {
+	validationsList := make([]sc2.Validations, len(validations))
 
-	for i, validation := range validations.List() {
+	for i, validation := range validations {
 		validation := validation.(map[string]interface{})
 		val := sc2.Validations{
 			Actual:     validation["actual"].(string),
@@ -1306,10 +1305,10 @@ func buildValidationsData(validations *schema.Set) []sc2.Validations {
 	return validationsList
 }
 
-func buildConfigurationData(configuration *schema.Set) sc2.Configuration {
+func buildConfigurationData(configuration []interface{}) sc2.Configuration {
 	var configurationData sc2.Configuration
 
-	config_list := configuration.List()
+	config_list := configuration
 	config_map := config_list[0].(map[string]interface{})
 
 	configurationData.Body = config_map["body"].(string)


### PR DESCRIPTION
Thanks to an internal report we've been notified that a API and HTTP tests were not correctly maintaining order of validation and setup steps.
- Changes from `TypeSet` to `TypeList` to maintain order
- Updates to docs

Revamp of acceptance tests planned and will be done as part of that work. 