### PR TITLE
update acceptance tests and validate functions for custom_properties

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -33,4 +33,4 @@ test:
 	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4                    
 
 testacc: 
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m   
+	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m   | sed '/X-Sf-Token/d'

--- a/synthetics/resource_api_check_v2.go
+++ b/synthetics/resource_api_check_v2.go
@@ -202,12 +202,12 @@ func resourceApiCheckV2() *schema.Resource {
 									"key": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile("^\\S+\\w{1,128}\\S{1,}")),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\S+\w{1,128}\S{1,}`), "custom_properties key can only consist of alphanumeric and underscore characters with no whitespace"),
 									},
 									"value": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile("^\\w{1,256}")),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\w{1,256}`), "custom_properties value can only consist of alphanumeric and underscore characters with no whitespace"),
 									},
 								},
 							},

--- a/synthetics/resource_api_check_v2.go
+++ b/synthetics/resource_api_check_v2.go
@@ -202,12 +202,12 @@ func resourceApiCheckV2() *schema.Resource {
 									"key": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\S+\w{1,128}\S{1,}`), "custom_properties key can only consist of alphanumeric and underscore characters with no whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]\w{1,128}$`), "custom_properties key must start with a letter and only consist of alphanumeric and underscore characters with no whitespace"),
 									},
 									"value": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\w{1,256}`), "custom_properties value can only consist of alphanumeric and underscore characters with no whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\w{1,256}$`), "custom_properties value can only consist of alphanumeric and underscore characters with no whitespace"),
 									},
 								},
 							},

--- a/synthetics/resource_api_check_v2_test.go
+++ b/synthetics/resource_api_check_v2_test.go
@@ -30,6 +30,10 @@ resource "synthetics_create_api_check_v2" "api_v2_foo_check" {
 		location_ids = ["aws-us-east-1"]
 		name = "2 Terraform-Api V2 Acceptance Checkaroo"
 		scheduling_strategy = "round_robin"
+		custom_properties {
+			key = "key"
+			value = "value"
+		}
 		requests {
 			configuration {
 				name = "Get products"
@@ -119,6 +123,10 @@ resource "synthetics_create_api_check_v2" "api_v2_foo_check" {
 		location_ids = ["aws-us-west-1"]
 		name = "2 Terraform-Api V2 Acceptance Checkaroo Updated"
 		scheduling_strategy = "concurrent"
+		custom_properties {
+			key = "beepkey"
+			value = "boopvalue"
+		}
 		requests {
 			configuration {
 				name = "Get productz"
@@ -215,6 +223,8 @@ func TestAccCreateUpdateApiCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.location_ids.0", "aws-us-east-1"),
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.name", "2 Terraform-Api V2 Acceptance Checkaroo"),
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.scheduling_strategy", "round_robin"),
+					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.custom_properties.0.key", "key"),
+					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.custom_properties.0.value", "value"),
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.requests.0.configuration.0.name", "Get products"),
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.requests.0.configuration.0.body", "\\'{\"alert_name\":\"the service is down\",\"url\":\"https://foo.com/bar\"}\\'\n"),
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.requests.0.configuration.0.headers.Accept", "application/json"),
@@ -284,6 +294,8 @@ func TestAccCreateUpdateApiCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.location_ids.0", "aws-us-west-1"),
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.name", "2 Terraform-Api V2 Acceptance Checkaroo Updated"),
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.scheduling_strategy", "concurrent"),
+					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.custom_properties.0.key", "beepkey"),
+					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.custom_properties.0.value", "boopvalue"),
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.requests.0.configuration.0.name", "Get productz"),
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.requests.0.configuration.0.body", "\\'{\"alert_name\":\"the service is down\",\"url\":\"https://foo.com/bar\"}\\'\n"),
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.requests.0.configuration.0.headers.Accept", "application/xml"),

--- a/synthetics/resource_browser_check_test.go
+++ b/synthetics/resource_browser_check_test.go
@@ -16,20 +16,16 @@ package synthetics
 
 import (
 	"fmt"
-	"os"
-	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	sc "github.com/splunk/syntheticsclient/syntheticsclient"
 )
 
 func TestAccBrowserCheckBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccBrowserCheckDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: rigorConfig + testAccBrowserCheckConfigBasic("ineffective browser test", "https://www.google.com", "real_browser", 15),
@@ -87,26 +83,4 @@ func testAccBrowserCheckExists(n string) resource.TestCheckFunc {
 		}
 		return nil
 	}
-}
-
-func testAccBrowserCheckDestroy(s *terraform.State) error {
-	token := os.Getenv("API_ACCESS_TOKEN")
-	client := sc.NewClient(token)
-	for _, rs := range s.RootModule().Resources {
-		switch rs.Type {
-		case "synthetics_create_browser_check":
-			checkId, err := strconv.Atoi(rs.Primary.ID)
-			if err != nil {
-				return fmt.Errorf("Error converting check id: %s", err)
-			}
-			check, _, err := client.GetCheck(checkId)
-			if check.ID != checkId || err != nil {
-				return fmt.Errorf("Found deleted check %s", rs.Primary.ID)
-			}
-		default:
-			return fmt.Errorf("Unexpected resource of type: %s", rs.Type)
-		}
-	}
-
-	return nil
 }

--- a/synthetics/resource_browser_check_v2.go
+++ b/synthetics/resource_browser_check_v2.go
@@ -271,12 +271,12 @@ func resourceBrowserCheckV2() *schema.Resource {
 									"key": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile("^\\S+\\w{1,128}\\S{1,}")),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\S+\w{1,128}\S{1,}`), "custom_properties key can only consist of alphanumeric and underscore characters with no whitespace"),
 									},
 									"value": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile("^\\w{1,256}")),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\w{1,256}`), "custom_properties value can only consist of alphanumeric and underscore characters with no whitespace"),
 									},
 								},
 							},

--- a/synthetics/resource_browser_check_v2.go
+++ b/synthetics/resource_browser_check_v2.go
@@ -271,12 +271,12 @@ func resourceBrowserCheckV2() *schema.Resource {
 									"key": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\S+\w{1,128}\S{1,}`), "custom_properties key can only consist of alphanumeric and underscore characters with no whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]\w{1,128}$`), "custom_properties key must start with a letter and only consist of alphanumeric and underscore characters with no whitespace"),
 									},
 									"value": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\w{1,256}`), "custom_properties value can only consist of alphanumeric and underscore characters with no whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\w{1,256}$`), "custom_properties value can only consist of alphanumeric and underscore characters with no whitespace"),
 									},
 								},
 							},

--- a/synthetics/resource_browser_check_v2_test.go
+++ b/synthetics/resource_browser_check_v2_test.go
@@ -30,6 +30,10 @@ resource "synthetics_create_browser_check_v2" "browser_v2_foo_check" {
     location_ids = ["aws-us-east-1"]
     name = "01-acceptance-Terraform-Browser-V2"
     scheduling_strategy = "round_robin"
+		custom_properties {
+			key = "key"
+			value = "value"
+		}
     advanced_settings {
       verify_certificates = true
       user_agent = "Mozilla/5.0 (X11; Linux x86_64; Splunk Synthetics) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36"
@@ -131,6 +135,10 @@ resource "synthetics_create_browser_check_v2" "browser_v2_foo_check" {
     location_ids = ["aws-us-west-1"]
     name = "01-acceptance-updated-Terraform-Browser-V2"
     scheduling_strategy = "concurrent"
+		custom_properties {
+			key = "beepkey"
+			value = "boopvalue"
+		}
     advanced_settings {
       verify_certificates = false
       user_agent = "Jozilla/5.0"
@@ -256,6 +264,8 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
           resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.location_ids.0", "aws-us-east-1"),
           resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.name", "01-acceptance-Terraform-Browser-V2"),
           resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.scheduling_strategy", "round_robin"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.custom_properties.0.key", "key"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.custom_properties.0.value", "value"),
           resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.verify_certificates", "true"),
           resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.user_agent", "Mozilla/5.0 (X11; Linux x86_64; Splunk Synthetics) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.114 Safari/537.36"),
           resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.collect_interactive_metrics", "false"),
@@ -330,6 +340,8 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
           resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.location_ids.0", "aws-us-west-1"),
           resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.name", "01-acceptance-updated-Terraform-Browser-V2"),
           resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.scheduling_strategy", "concurrent"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.custom_properties.0.key", "beepkey"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.custom_properties.0.value", "boopvalue"),
           resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.verify_certificates", "false"),
           resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.user_agent", "Jozilla/5.0"),
           resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.collect_interactive_metrics", "false"),

--- a/synthetics/resource_http_check_v2.go
+++ b/synthetics/resource_http_check_v2.go
@@ -176,12 +176,12 @@ func resourceHttpCheckV2() *schema.Resource {
 									"key": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\S+\w{1,128}\S{1,}`), "custom_properties key can only consist of alphanumeric and underscore characters with no whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]\w{1,128}$`), "custom_properties key must start with a letter and only consist of alphanumeric and underscore characters with no whitespace"),
 									},
 									"value": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\w{1,256}`), "custom_properties value can only consist of alphanumeric and underscore characters with no whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\w{1,256}$`), "custom_properties value can only consist of alphanumeric and underscore characters with no whitespace"),
 									},
 								},
 							},

--- a/synthetics/resource_http_check_v2.go
+++ b/synthetics/resource_http_check_v2.go
@@ -176,12 +176,12 @@ func resourceHttpCheckV2() *schema.Resource {
 									"key": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile("^\\S+\\w{1,128}\\S{1,}")),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\S+\w{1,128}\S{1,}`), "custom_properties key can only consist of alphanumeric and underscore characters with no whitespace"),
 									},
 									"value": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile("^\\w{1,256}")),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\w{1,256}`), "custom_properties value can only consist of alphanumeric and underscore characters with no whitespace"),
 									},
 								},
 							},

--- a/synthetics/resource_http_check_v2_test.go
+++ b/synthetics/resource_http_check_v2_test.go
@@ -31,6 +31,10 @@ resource "synthetics_create_http_check_v2" "http_v2_foo_check" {
     type = "http"
     url = "https://www.splunk.com"
     scheduling_strategy = "round_robin"
+		custom_properties {
+			key = "key"
+			value = "value"
+		}
     request_method = "POST"
     verify_certificates = true
     user_agent = "Another User of Agents"
@@ -72,6 +76,10 @@ resource "synthetics_create_http_check_v2" "http_v2_foo_check" {
     type = "http"
     url = "https://www.duckduckgo.com"
     scheduling_strategy = "concurrent"
+		custom_properties {
+			key = "beepkey"
+			value = "boopvalue"
+		}
     request_method = "PUT"
     verify_certificates = false
     user_agent = "Another User of Agents and snake oil"
@@ -121,6 +129,8 @@ func TestAccCreateUpdateHttpCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.type", "http"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.url", "https://www.splunk.com"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.scheduling_strategy", "round_robin"),
+					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.custom_properties.0.key", "key"),
+					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.custom_properties.0.value", "value"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.request_method", "POST"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.verify_certificates", "true"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.user_agent", "Another User of Agents"),
@@ -159,6 +169,8 @@ func TestAccCreateUpdateHttpCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.type", "http"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.url", "https://www.duckduckgo.com"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.scheduling_strategy", "concurrent"),
+					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.custom_properties.0.key", "beepkey"),
+					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.custom_properties.0.value", "boopvalue"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.request_method", "PUT"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.verify_certificates", "false"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.user_agent", "Another User of Agents and snake oil"),

--- a/synthetics/resource_port_check_v2.go
+++ b/synthetics/resource_port_check_v2.go
@@ -108,12 +108,12 @@ func resourcePortCheckV2() *schema.Resource {
 									"key": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile("^\\S+\\w{1,128}\\S{1,}")),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\S+\w{1,128}\S{1,}`), "custom_properties key can only consist of alphanumeric and underscore characters with no whitespace"),
 									},
 									"value": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile("^\\w{1,256}")),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\w{1,256}`), "custom_properties value can only consist of alphanumeric and underscore characters with no whitespace"),
 									},
 								},
 							},

--- a/synthetics/resource_port_check_v2.go
+++ b/synthetics/resource_port_check_v2.go
@@ -108,12 +108,12 @@ func resourcePortCheckV2() *schema.Resource {
 									"key": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\S+\w{1,128}\S{1,}`), "custom_properties key can only consist of alphanumeric and underscore characters with no whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]\w{1,128}$`), "custom_properties key must start with a letter and only consist of alphanumeric and underscore characters with no whitespace"),
 									},
 									"value": {
 										Type:     schema.TypeString,
 										Optional: true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\w{1,256}`), "custom_properties value can only consist of alphanumeric and underscore characters with no whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\w{1,256}$`), "custom_properties value can only consist of alphanumeric and underscore characters with no whitespace"),
 									},
 								},
 							},

--- a/synthetics/resource_port_check_v2_test.go
+++ b/synthetics/resource_port_check_v2_test.go
@@ -28,6 +28,10 @@ resource "synthetics_create_port_check_v2" "port_v2_foo_check" {
     frequency = 5
     location_ids = ["aws-us-west-2", "aws-us-east-1"]
     scheduling_strategy = "round_robin"
+		custom_properties {
+			key = "key"
+			value = "value"
+		}
     name = "acceptance-Terraform-PORT-V2"
     port = 8081
     protocol = "udp"
@@ -44,6 +48,10 @@ resource "synthetics_create_port_check_v2" "port_v2_foo_check" {
     frequency = 15
     location_ids = ["aws-us-east-1"]
     scheduling_strategy = "concurrent"
+		custom_properties {
+			key = "beepkey"
+			value = "boopvalue"
+		}
     name = "acceptance-updated-Terraform-PORT-V2"
     port = 8082
     protocol = "tcp"
@@ -68,6 +76,8 @@ func TestAccCreateUpdatePortCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.location_ids.0", "aws-us-west-2"),
 					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.location_ids.1", "aws-us-east-1"),
 					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.scheduling_strategy", "round_robin"),
+					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.custom_properties.0.key", "key"),
+					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.custom_properties.0.value", "value"),
 					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.name", "acceptance-Terraform-PORT-V2"),
 					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.port", "8081"),
 					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.protocol", "udp"),
@@ -89,6 +99,8 @@ func TestAccCreateUpdatePortCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.frequency", "15"),
 					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.location_ids.0", "aws-us-east-1"),
 					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.scheduling_strategy", "concurrent"),
+					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.custom_properties.0.key", "beepkey"),
+					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.custom_properties.0.value", "boopvalue"),
 					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.name", "acceptance-updated-Terraform-PORT-V2"),
 					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.port", "8082"),
 					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.protocol", "tcp"),


### PR DESCRIPTION
1. Adds `custom_properties` to acceptance tests
2. Updates the `ValidateFunc` for `custom_properties` slightly to include an error message and also remove need for escaping with backticks 
3. Remove unneeded delete function from old rigor acceptance tests (this is handled by the tf testing suite)
4. `sed` out any possible token leakage from the synthetics client if `TF_LOG` is set below error during `make testacc`