### PR TITLE
Version bump (2.0.3) and docs

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -3,7 +3,7 @@ HOSTNAME=github.com
 NAMESPACE=splunk
 NAME=synthetics
 BINARY=terraform-provider-${NAME}
-VERSION=2.0.2
+VERSION=2.0.3
 
 default: install
 

--- a/docs/data-sources/api_v2_check.md
+++ b/docs/data-sources/api_v2_check.md
@@ -36,6 +36,7 @@ data "synthetics_api_v2_check" "datasource_check_api" {
 
 Optional:
 
+- `custom_properties` (Block Set) (see [below for nested schema](#nestedblock--test--custom_properties))
 - `frequency` (Number)
 - `location_ids` (List of String)
 
@@ -50,6 +51,15 @@ Read-Only:
 - `scheduling_strategy` (String)
 - `type` (String)
 - `updated_at` (String)
+
+<a id="nestedblock--test--custom_properties"></a>
+### Nested Schema for `test.custom_properties`
+
+Optional:
+
+- `key` (String)
+- `value` (String)
+
 
 <a id="nestedatt--test--device"></a>
 ### Nested Schema for `test.device`

--- a/docs/data-sources/browser_v2_check.md
+++ b/docs/data-sources/browser_v2_check.md
@@ -34,6 +34,10 @@ data "synthetics_browser_v2_check" "datasource_check_browser" {
 <a id="nestedblock--test"></a>
 ### Nested Schema for `test`
 
+Optional:
+
+- `custom_properties` (Block Set) (see [below for nested schema](#nestedblock--test--custom_properties))
+
 Read-Only:
 
 - `active` (Boolean)
@@ -49,6 +53,15 @@ Read-Only:
 - `transactions` (Set of Object) (see [below for nested schema](#nestedatt--test--transactions))
 - `type` (String)
 - `updated_at` (String)
+
+<a id="nestedblock--test--custom_properties"></a>
+### Nested Schema for `test.custom_properties`
+
+Optional:
+
+- `key` (String)
+- `value` (String)
+
 
 <a id="nestedatt--test--advanced_settings"></a>
 ### Nested Schema for `test.advanced_settings`

--- a/docs/data-sources/http_v2_check.md
+++ b/docs/data-sources/http_v2_check.md
@@ -36,6 +36,7 @@ data "synthetics_http_v2_check" "datasource_check_http" {
 
 Optional:
 
+- `custom_properties` (Block Set) (see [below for nested schema](#nestedblock--test--custom_properties))
 - `frequency` (Number)
 - `headers` (Block Set) (see [below for nested schema](#nestedblock--test--headers))
 - `validations` (Block Set) (see [below for nested schema](#nestedblock--test--validations))
@@ -55,6 +56,15 @@ Read-Only:
 - `url` (String)
 - `user_agent` (String)
 - `verify_certificates` (Boolean)
+
+<a id="nestedblock--test--custom_properties"></a>
+### Nested Schema for `test.custom_properties`
+
+Optional:
+
+- `key` (String)
+- `value` (String)
+
 
 <a id="nestedblock--test--headers"></a>
 ### Nested Schema for `test.headers`

--- a/docs/data-sources/port_v2_check.md
+++ b/docs/data-sources/port_v2_check.md
@@ -36,6 +36,7 @@ data "synthetics_port_v2_check" "datasource_check_port" {
 
 Optional:
 
+- `custom_properties` (Block Set) (see [below for nested schema](#nestedblock--test--custom_properties))
 - `location_ids` (List of String)
 
 Read-Only:
@@ -51,5 +52,13 @@ Read-Only:
 - `scheduling_strategy` (String)
 - `type` (String)
 - `updated_at` (String)
+
+<a id="nestedblock--test--custom_properties"></a>
+### Nested Schema for `test.custom_properties`
+
+Optional:
+
+- `key` (String)
+- `value` (String)
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ description: |-
 terraform {
   required_providers {
     synthetics = {
-      version = "2.0.2"
+      version = "2.0.3"
       source  = "splunk/synthetics"
     }
   }
@@ -34,8 +34,9 @@ provider "synthetics" {
 
 ### Required
 
-- `apikey` (String) Splunk Observability API Key. Will pull from `OBSERVABILITY_API_TOKEN` environment variable if available.
 - `product` (String) One of: `observability` or `rigor`
+
+### Optional
+
+- `apikey` (String) Splunk Observability API Key. Will pull from `OBSERVABILITY_API_TOKEN` environment variable if available.
 - `realm` (String) Splunk Observability Realm (E.G. `us1`). Will pull from `REALM` environment variable if available. For Rigor use realm rigor
-
-

--- a/docs/resources/create_api_check_v2.md
+++ b/docs/resources/create_api_check_v2.md
@@ -21,6 +21,10 @@ resource "synthetics_create_api_check_v2" "full_api_v2_foo_check" {
     location_ids = ["aws-us-east-1"]
     name = "2 Terraform-Api V2 Checkaroo"
     scheduling_strategy = "round_robin"
+    custom_properties {
+			key = "key"
+			value = "value"
+		}
     requests {
       configuration {
         body = "\\'{\"alert_name\":\"the service is down\",\"url\":\"https://foo.com/bar\"}\\'\n"
@@ -163,8 +167,18 @@ Required:
 
 Optional:
 
+- `custom_properties` (Block Set) (see [below for nested schema](#nestedblock--test--custom_properties))
 - `requests` (Block List) (see [below for nested schema](#nestedblock--test--requests))
 - `scheduling_strategy` (String)
+
+<a id="nestedblock--test--custom_properties"></a>
+### Nested Schema for `test.custom_properties`
+
+Optional:
+
+- `key` (String)
+- `value` (String)
+
 
 <a id="nestedblock--test--requests"></a>
 ### Nested Schema for `test.requests`

--- a/docs/resources/create_browser_check_v2.md
+++ b/docs/resources/create_browser_check_v2.md
@@ -21,6 +21,10 @@ resource "synthetics_create_browser_check_v2" "long_browser_v2_foo_check" {
     location_ids = ["aws-us-east-1"]
     name = "0011aTerraform-Browser V2 Checkaroo"
     scheduling_strategy = "round_robin"
+    custom_properties {
+			key = "key"
+			value = "value"
+		}
     transactions {
       name = "First Synthetic transaction"
       steps {
@@ -180,6 +184,7 @@ Required:
 Optional:
 
 - `active` (Boolean)
+- `custom_properties` (Block Set) (see [below for nested schema](#nestedblock--test--custom_properties))
 - `device_id` (Number)
 - `frequency` (Number)
 - `location_ids` (List of String)
@@ -280,5 +285,16 @@ Optional:
 Optional:
 
 - `url` (String)
+
+
+
+
+<a id="nestedblock--test--custom_properties"></a>
+### Nested Schema for `test.custom_properties`
+
+Optional:
+
+- `key` (String)
+- `value` (String)
 
 

--- a/docs/resources/create_http_check_v2.md
+++ b/docs/resources/create_http_check_v2.md
@@ -22,6 +22,10 @@ resource "synthetics_create_http_check_v2" "http_v2_foo_check" {
     type = "http"
     url = "https://www.splunk.com"
     scheduling_strategy = "round_robin"
+    custom_properties {
+			key = "key"
+			value = "value"
+		}
     request_method = "GET"
     verify_certificates = true
     user_agent = "Another User of Agents"
@@ -65,6 +69,7 @@ Required:
 Optional:
 
 - `body` (String)
+- `custom_properties` (Block Set) (see [below for nested schema](#nestedblock--test--custom_properties))
 - `headers` (Block Set) (see [below for nested schema](#nestedblock--test--headers))
 - `scheduling_strategy` (String)
 - `type` (String)
@@ -76,6 +81,15 @@ Read-Only:
 - `created_at` (String)
 - `id` (Number) The ID of this resource.
 - `updated_at` (String)
+
+<a id="nestedblock--test--custom_properties"></a>
+### Nested Schema for `test.custom_properties`
+
+Optional:
+
+- `key` (String)
+- `value` (String)
+
 
 <a id="nestedblock--test--headers"></a>
 ### Nested Schema for `test.headers`

--- a/docs/resources/create_port_check_v2.md
+++ b/docs/resources/create_port_check_v2.md
@@ -23,6 +23,10 @@ resource "synthetics_create_port_check_v2" "port_v2_foo_check" {
     location_ids = ["aws-us-west-2"]
     frequency = 5
     scheduling_strategy = "concurrent"
+    custom_properties {
+			key = "key"
+			value = "value"
+		}
     active = true 
   }    
 }
@@ -54,6 +58,7 @@ Required:
 
 Optional:
 
+- `custom_properties` (Block Set) (see [below for nested schema](#nestedblock--test--custom_properties))
 - `scheduling_strategy` (String)
 - `type` (String)
 - `url` (String)
@@ -63,5 +68,13 @@ Read-Only:
 - `created_at` (String)
 - `id` (Number) The ID of this resource.
 - `updated_at` (String)
+
+<a id="nestedblock--test--custom_properties"></a>
+### Nested Schema for `test.custom_properties`
+
+Optional:
+
+- `key` (String)
+- `value` (String)
 
 

--- a/examples/all-v2-resources.tf
+++ b/examples/all-v2-resources.tf
@@ -1,7 +1,7 @@
 # terraform {
 #   required_providers {
 #     synthetics = {
-#       version = "2.0.0"
+#       version = "2.0.3"
 #       source  = "splunk/synthetics"
 #     }
 #   }
@@ -48,6 +48,10 @@
 #     verify_certificates = true
 #     user_agent = "Another User of Agents"
 #     body = null
+#     custom_properties {
+# 			key = "key"
+# 			value = "value"
+# 		}
 #     headers {
 #       name = "Synthetic_transaction_1"
 #       value = "batman is the man"
@@ -70,6 +74,10 @@
 #     location_ids = ["aws-us-west-2"]
 #     frequency = 5
 #     scheduling_strategy = "concurrent"
+#     custom_properties {
+# 			key = "key"
+# 			value = "value"
+# 		}
 #     active = true 
 #   }    
 # }
@@ -83,6 +91,10 @@
 #     location_ids = ["aws-us-east-1"]
 #     name = "0011aTerraform-Browser V2 Checkaroo"
 #     scheduling_strategy = "round_robin"
+#     custom_properties {
+# 			key = "key"
+# 			value = "value"
+# 		}
 #     transactions {
 #       name = "First Synthetic transaction"
 #       steps {
@@ -226,6 +238,10 @@
 #     location_ids = ["aws-us-east-1"]
 #     name = "22aTerraform-Browser V2 Checkaroo"
 #     scheduling_strategy = "round_robin"
+#     custom_properties {
+# 			key = "key"
+# 			value = "value"
+# 		}
 #     advanced_settings {
 #       verify_certificates = true
 #     }
@@ -256,6 +272,10 @@
 #     location_ids = ["aws-us-east-1"]
 #     name = "1 Terraform-Api V2 Checkaroo"
 #     scheduling_strategy = "round_robin"
+#     custom_properties {
+# 			key = "key"
+# 			value = "value"
+# 		}
 #     requests {
 #         configuration {
 #           name = "Get products"
@@ -274,6 +294,10 @@
 #     location_ids = ["aws-us-east-1"]
 #     name = "2 Terraform-Api V2 Checkaroo"
 #     scheduling_strategy = "round_robin"
+#     custom_properties {
+# 			key = "key"
+# 			value = "value"
+# 		}
 #     requests {
 #       configuration {
 #         body = "\\'{\"alert_name\":\"the service is down\",\"url\":\"https://foo.com/bar\"}\\'\n"

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     synthetics = {
-      version = "2.0.2"
+      version = "2.0.3"
       source  = "splunk/synthetics"
     }
   }

--- a/examples/resources/synthetics_create_api_check_v2/resource.tf
+++ b/examples/resources/synthetics_create_api_check_v2/resource.tf
@@ -6,6 +6,10 @@ resource "synthetics_create_api_check_v2" "full_api_v2_foo_check" {
     location_ids = ["aws-us-east-1"]
     name = "2 Terraform-Api V2 Checkaroo"
     scheduling_strategy = "round_robin"
+    custom_properties {
+			key = "key"
+			value = "value"
+		}
     requests {
       configuration {
         body = "\\'{\"alert_name\":\"the service is down\",\"url\":\"https://foo.com/bar\"}\\'\n"

--- a/examples/resources/synthetics_create_browser_check_v2/resource.tf
+++ b/examples/resources/synthetics_create_browser_check_v2/resource.tf
@@ -6,6 +6,10 @@ resource "synthetics_create_browser_check_v2" "long_browser_v2_foo_check" {
     location_ids = ["aws-us-east-1"]
     name = "0011aTerraform-Browser V2 Checkaroo"
     scheduling_strategy = "round_robin"
+    custom_properties {
+			key = "key"
+			value = "value"
+		}
     transactions {
       name = "First Synthetic transaction"
       steps {

--- a/examples/resources/synthetics_create_http_check_v2/resource.tf
+++ b/examples/resources/synthetics_create_http_check_v2/resource.tf
@@ -7,6 +7,10 @@ resource "synthetics_create_http_check_v2" "http_v2_foo_check" {
     type = "http"
     url = "https://www.splunk.com"
     scheduling_strategy = "round_robin"
+    custom_properties {
+			key = "key"
+			value = "value"
+		}
     request_method = "GET"
     verify_certificates = true
     user_agent = "Another User of Agents"

--- a/examples/resources/synthetics_create_port_check_v2/resource.tf
+++ b/examples/resources/synthetics_create_port_check_v2/resource.tf
@@ -8,6 +8,10 @@ resource "synthetics_create_port_check_v2" "port_v2_foo_check" {
     location_ids = ["aws-us-west-2"]
     frequency = 5
     scheduling_strategy = "concurrent"
+    custom_properties {
+			key = "key"
+			value = "value"
+		}
     active = true 
   }    
 }


### PR DESCRIPTION
1. Update examples
2. Run `tfplugindocs generate --provider-name synthetics` to generate docs with updated examples
3. Bump minor version to 2.0.3 for release