### PR TITLE
SYN-3741: Added automatic_retries to all /test api responses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/splunk/syntheticsclient v1.0.3
-	github.com/splunk/syntheticsclient/v2 v2.0.5
+	github.com/splunk/syntheticsclient/v2 v2.0.7
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -176,6 +176,8 @@ github.com/splunk/syntheticsclient v1.0.3 h1:I3PUgTnKZsCNGFH8OgBiQ+sZYYxOwcLmkbi
 github.com/splunk/syntheticsclient v1.0.3/go.mod h1:riH4plM9ySr2lHnWi2E4cocaP9qqlRQHKX6nisiyq6E=
 github.com/splunk/syntheticsclient/v2 v2.0.5 h1:IWmXf1zqQMIrPNW/BYFe4geTvirXybWH7LXxkPBcZ8k=
 github.com/splunk/syntheticsclient/v2 v2.0.5/go.mod h1:xP4ikfSyA0eVyI72sa11hi9yUDBaQhB5mtW6QSClaWw=
+github.com/splunk/syntheticsclient/v2 v2.0.7 h1:cfZPoIW/tX/5DiKLv+OZsiYiPGHYT1j5CsouGhSXZRw=
+github.com/splunk/syntheticsclient/v2 v2.0.7/go.mod h1:xP4ikfSyA0eVyI72sa11hi9yUDBaQhB5mtW6QSClaWw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/synthetics/data_source_apicheck_v2.go
+++ b/synthetics/data_source_apicheck_v2.go
@@ -270,6 +270,10 @@ func dataSourceApiCheckV2() *schema.Resource {
 								},
 							},
 						},
+						"automatic_retries": {
+                            Type:     schema.TypeInt,
+                            Computed: true,
+                        },
 					},
 				},
 			},

--- a/synthetics/data_source_browsercheck_v2.go
+++ b/synthetics/data_source_browsercheck_v2.go
@@ -397,6 +397,10 @@ func dataSourceBrowserCheckV2() *schema.Resource {
 								},
 							},
 						},
+						"automatic_retries": {
+                            Type:     schema.TypeInt,
+                            Computed: true,
+                        },
 					},
 				},
 			},

--- a/synthetics/data_source_httpcheck_v2.go
+++ b/synthetics/data_source_httpcheck_v2.go
@@ -175,6 +175,10 @@ func dataSourceHttpCheckV2() *schema.Resource {
 								},
 							},
 						},
+						"automatic_retries": {
+                            Type:     schema.TypeInt,
+                            Computed: true,
+                        },
 					},
 				},
 			},

--- a/synthetics/data_source_portcheck_v2.go
+++ b/synthetics/data_source_portcheck_v2.go
@@ -101,6 +101,10 @@ func dataSourcePortCheckV2() *schema.Resource {
 								},
 							},
 						},
+						"automatic_retries": {
+                            Type:     schema.TypeInt,
+                            Computed: true,
+                        },
 					},
 				},
 			},

--- a/synthetics/resource_api_check_v2.go
+++ b/synthetics/resource_api_check_v2.go
@@ -212,6 +212,10 @@ func resourceApiCheckV2() *schema.Resource {
 								},
 							},
 						},
+						"automatic_retries": {
+                            Type:     schema.TypeInt,
+                            Computed: true,
+                        },
 					},
 				},
 			},

--- a/synthetics/resource_api_check_v2.go
+++ b/synthetics/resource_api_check_v2.go
@@ -215,6 +215,7 @@ func resourceApiCheckV2() *schema.Resource {
 						"automatic_retries": {
                             Type:     schema.TypeInt,
                             Computed: true,
+							Optional: true,
                         },
 					},
 				},

--- a/synthetics/resource_api_check_v2_test.go
+++ b/synthetics/resource_api_check_v2_test.go
@@ -30,6 +30,7 @@ resource "synthetics_create_api_check_v2" "api_v2_foo_check" {
 		location_ids = ["aws-us-east-1"]
 		name = "2 Terraform-Api V2 Acceptance Checkaroo"
 		scheduling_strategy = "round_robin"
+		automatic_retries = 1
 		custom_properties {
 			key = "key"
 			value = "value"
@@ -123,6 +124,7 @@ resource "synthetics_create_api_check_v2" "api_v2_foo_check" {
 		location_ids = ["aws-us-west-1"]
 		name = "2 Terraform-Api V2 Acceptance Checkaroo Updated"
 		scheduling_strategy = "concurrent"
+		automatic_retries = 0
 		custom_properties {
 			key = "beepkey"
 			value = "boopvalue"
@@ -220,6 +222,7 @@ func TestAccCreateUpdateApiCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.active", "true"),
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.device_id", "1"),
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.frequency", "5"),
+					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.automatic_retries", "1"),
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.location_ids.0", "aws-us-east-1"),
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.name", "2 Terraform-Api V2 Acceptance Checkaroo"),
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.scheduling_strategy", "round_robin"),
@@ -291,6 +294,7 @@ func TestAccCreateUpdateApiCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.active", "false"),
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.device_id", "2"),
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.frequency", "15"),
+					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.automatic_retries", "0"),
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.location_ids.0", "aws-us-west-1"),
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.name", "2 Terraform-Api V2 Acceptance Checkaroo Updated"),
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.scheduling_strategy", "concurrent"),

--- a/synthetics/resource_browser_check_v2.go
+++ b/synthetics/resource_browser_check_v2.go
@@ -281,6 +281,10 @@ func resourceBrowserCheckV2() *schema.Resource {
 								},
 							},
 						},
+						"automatic_retries": {
+                            Type:     schema.TypeInt,
+                            Computed: true,
+                        },
 					},
 				},
 			},

--- a/synthetics/resource_browser_check_v2.go
+++ b/synthetics/resource_browser_check_v2.go
@@ -284,6 +284,7 @@ func resourceBrowserCheckV2() *schema.Resource {
 						"automatic_retries": {
                             Type:     schema.TypeInt,
                             Computed: true,
+							Optional: true,
                         },
 					},
 				},

--- a/synthetics/resource_browser_check_v2_test.go
+++ b/synthetics/resource_browser_check_v2_test.go
@@ -28,6 +28,7 @@ resource "synthetics_create_browser_check_v2" "browser_v2_foo_check" {
     device_id = 1  
     frequency = 5
     location_ids = ["aws-us-east-1"]
+    automatic_retries = 1
     name = "01-acceptance-Terraform-Browser-V2"
     scheduling_strategy = "round_robin"
 		custom_properties {
@@ -133,6 +134,7 @@ resource "synthetics_create_browser_check_v2" "browser_v2_foo_check" {
     device_id = 2  
     frequency = 15
     location_ids = ["aws-us-west-1"]
+    automatic_retries = 0
     name = "01-acceptance-updated-Terraform-Browser-V2"
     scheduling_strategy = "concurrent"
 		custom_properties {
@@ -261,6 +263,7 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.active", "true"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.device_id", "1"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.frequency", "5"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.automatic_retries", "1"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.location_ids.0", "aws-us-east-1"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.name", "01-acceptance-Terraform-Browser-V2"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.scheduling_strategy", "round_robin"),
@@ -337,6 +340,7 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.active", "false"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.device_id", "2"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.frequency", "15"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.automatic_retries", "0"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.location_ids.0", "aws-us-west-1"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.name", "01-acceptance-updated-Terraform-Browser-V2"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.scheduling_strategy", "concurrent"),

--- a/synthetics/resource_http_check_v2.go
+++ b/synthetics/resource_http_check_v2.go
@@ -186,6 +186,10 @@ func resourceHttpCheckV2() *schema.Resource {
 								},
 							},
 						},
+						"automatic_retries": {
+                            Type:     schema.TypeInt,
+                            Computed: true,
+                        },
 					},
 				},
 			},

--- a/synthetics/resource_http_check_v2.go
+++ b/synthetics/resource_http_check_v2.go
@@ -189,6 +189,7 @@ func resourceHttpCheckV2() *schema.Resource {
 						"automatic_retries": {
                             Type:     schema.TypeInt,
                             Computed: true,
+							Optional: true,
                         },
 					},
 				},

--- a/synthetics/resource_http_check_v2_test.go
+++ b/synthetics/resource_http_check_v2_test.go
@@ -30,6 +30,7 @@ resource "synthetics_create_http_check_v2" "http_v2_foo_check" {
     name = "01-acceptance-Terraform-HTTP-V2"
     type = "http"
     url = "https://www.splunk.com"
+    automatic_retries = 1
     scheduling_strategy = "round_robin"
 		custom_properties {
 			key = "key"
@@ -75,6 +76,7 @@ resource "synthetics_create_http_check_v2" "http_v2_foo_check" {
     name = "01-acceptance-updated-Terraform-HTTP-V2"
     type = "http"
     url = "https://www.duckduckgo.com"
+    automatic_retries = 0
     scheduling_strategy = "concurrent"
 		custom_properties {
 			key = "beepkey"
@@ -123,6 +125,7 @@ func TestAccCreateUpdateHttpCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.#", "1"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.active", "true"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.frequency", "5"),
+					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.automatic_retries", "1"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.location_ids.0", "aws-us-east-1"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.location_ids.1", "aws-us-west-1"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.name", "01-acceptance-Terraform-HTTP-V2"),
@@ -164,6 +167,7 @@ func TestAccCreateUpdateHttpCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.#", "1"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.active", "false"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.frequency", "15"),
+					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.automatic_retries", "0"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.location_ids.0", "aws-us-west-1"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.name", "01-acceptance-updated-Terraform-HTTP-V2"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.type", "http"),

--- a/synthetics/resource_port_check_v2.go
+++ b/synthetics/resource_port_check_v2.go
@@ -118,6 +118,10 @@ func resourcePortCheckV2() *schema.Resource {
 								},
 							},
 						},
+						"automatic_retries": {
+                            Type:     schema.TypeInt,
+                            Computed: true,
+                        },
 					},
 				},
 			},

--- a/synthetics/resource_port_check_v2.go
+++ b/synthetics/resource_port_check_v2.go
@@ -121,6 +121,7 @@ func resourcePortCheckV2() *schema.Resource {
 						"automatic_retries": {
                             Type:     schema.TypeInt,
                             Computed: true,
+							Optional: true,
                         },
 					},
 				},

--- a/synthetics/resource_port_check_v2_test.go
+++ b/synthetics/resource_port_check_v2_test.go
@@ -27,6 +27,7 @@ resource "synthetics_create_port_check_v2" "port_v2_foo_check" {
     active = true 
     frequency = 5
     location_ids = ["aws-us-west-2", "aws-us-east-1"]
+    automatic_retries = 1
     scheduling_strategy = "round_robin"
 		custom_properties {
 			key = "key"
@@ -47,6 +48,7 @@ resource "synthetics_create_port_check_v2" "port_v2_foo_check" {
     active = false 
     frequency = 15
     location_ids = ["aws-us-east-1"]
+    automatic_retries = 0
     scheduling_strategy = "concurrent"
 		custom_properties {
 			key = "beepkey"
@@ -73,6 +75,7 @@ func TestAccCreateUpdatePortCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.#", "1"),
 					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.active", "true"),
 					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.frequency", "5"),
+					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.automatic_retries", "1"),
 					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.location_ids.0", "aws-us-west-2"),
 					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.location_ids.1", "aws-us-east-1"),
 					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.scheduling_strategy", "round_robin"),
@@ -97,6 +100,7 @@ func TestAccCreateUpdatePortCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.#", "1"),
 					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.active", "false"),
 					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.frequency", "15"),
+					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.automatic_retries", "0"),
 					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.location_ids.0", "aws-us-east-1"),
 					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.scheduling_strategy", "concurrent"),
 					resource.TestCheckResourceAttr("synthetics_create_port_check_v2.port_v2_foo_check", "test.0.custom_properties.0.key", "beepkey"),

--- a/synthetics/structures.go
+++ b/synthetics/structures.go
@@ -48,6 +48,7 @@ func flattenApiV2Read(checkApiV2 *sc2.ApiCheckV2Response) []interface{} {
 	apiV2 := make(map[string]interface{})
 
 	apiV2["active"] = checkApiV2.Test.Active
+	apiV2["automatic_retries"] = checkApiV2.Test.Automaticretries
 
 	if checkApiV2.Test.Frequency != 0 {
 		apiV2["frequency"] = checkApiV2.Test.Frequency
@@ -81,6 +82,7 @@ func flattenApiV2Data(checkApiV2 *sc2.ApiCheckV2Response) []interface{} {
 	apiV2 := make(map[string]interface{})
 
 	apiV2["active"] = checkApiV2.Test.Active
+	apiV2["automatic_retries"] = checkApiV2.Test.Automaticretries
 
 	if checkApiV2.Test.Createdat.IsZero() {
 	} else {
@@ -303,6 +305,7 @@ func flattenBrowserV2Read(checkBrowserV2 *sc2.BrowserCheckV2Response) []interfac
 	browserV2 := make(map[string]interface{})
 
 	browserV2["active"] = checkBrowserV2.Test.Active
+	browserV2["automatic_retries"] = checkBrowserV2.Test.Automaticretries
 
 	browserV2["device_id"] = checkBrowserV2.Test.Device.ID
 
@@ -339,6 +342,7 @@ func flattenBrowserV2Data(checkBrowserV2 *sc2.BrowserCheckV2Response) []interfac
 	browserV2 := make(map[string]interface{})
 
 	browserV2["active"] = checkBrowserV2.Test.Active
+	browserV2["automatic_retries"] = checkBrowserV2.Test.Automaticretries
 
 	if checkBrowserV2.Test.Createdat.IsZero() {
 	} else {
@@ -401,6 +405,7 @@ func flattenHttpV2Read(checkHttpV2 *sc2.HttpCheckV2Response) []interface{} {
 	}
 
 	httpV2["active"] = checkHttpV2.Test.Active
+	httpV2["automatic_retries"] = checkHttpV2.Test.Automaticretries
 
 	if checkHttpV2.Test.Frequency != 0 {
 		httpV2["frequency"] = checkHttpV2.Test.Frequency
@@ -459,6 +464,7 @@ func flattenHttpV2Data(checkHttpV2 *sc2.HttpCheckV2Response) []interface{} {
 	}
 
 	httpV2["active"] = checkHttpV2.Test.Active
+	httpV2["automatic_retries"] = checkHttpV2.Test.Automaticretries
 
 	if checkHttpV2.Test.Frequency != 0 {
 		httpV2["frequency"] = checkHttpV2.Test.Frequency
@@ -527,6 +533,7 @@ func flattenPortCheckV2Read(checkPortV2 *sc2.PortCheckV2Response) []interface{} 
 	}
 
 	portV2["active"] = checkPortV2.Test.Active
+	portV2["automatic_retries"] = checkPortV2.Test.Automaticretries
 
 	if checkPortV2.Test.Frequency != 0 {
 		portV2["frequency"] = checkPortV2.Test.Frequency
@@ -575,6 +582,7 @@ func flattenPortCheckV2Data(checkPortV2 *sc2.PortCheckV2Response) []interface{} 
 	}
 
 	portV2["active"] = checkPortV2.Test.Active
+	portV2["automatic_retries"] = checkPortV2.Test.Automaticretries
 
 	if checkPortV2.Test.Frequency != 0 {
 		portV2["frequency"] = checkPortV2.Test.Frequency
@@ -1115,6 +1123,7 @@ func buildApiV2Data(d *schema.ResourceData) sc2.ApiCheckV2Input {
 			apiv2.Test.Active = api["active"].(bool)
 			apiv2.Test.Deviceid = api["device_id"].(int)
 			apiv2.Test.Frequency = api["frequency"].(int)
+			apiv2.Test.Automaticretries = api["automatic_retries"].(int)
 			apiv2.Test.Locationids = buildLocationIdData(api["location_ids"].([]interface{}))
 			apiv2.Test.Name = api["name"].(string)
 			apiv2.Test.Requests = buildRequestsData(api["requests"].(([]interface{})))
@@ -1135,6 +1144,7 @@ func buildBrowserV2Data(d *schema.ResourceData) sc2.BrowserCheckV2Input {
 			browserv2.Test.Active = browser["active"].(bool)
 			browserv2.Test.DeviceID = browser["device_id"].(int)
 			browserv2.Test.Frequency = browser["frequency"].(int)
+			browserv2.Test.Automaticretries = browser["automatic_retries"].(int)
 			browserv2.Test.LocationIds = buildLocationIdData(browser["location_ids"].([]interface{}))
 			browserv2.Test.Name = browser["name"].(string)
 			browserv2.Test.Transactions = buildBusinessTransactionsData(browser["transactions"].([]interface{}))
@@ -1159,6 +1169,7 @@ func buildHttpV2Data(d *schema.ResourceData) sc2.HttpCheckV2Input {
 			httpv2.Test.URL = http["url"].(string)
 			httpv2.Test.LocationIds = buildLocationIdData(http["location_ids"].([]interface{}))
 			httpv2.Test.Frequency = http["frequency"].(int)
+			httpv2.Test.Automaticretries = http["automatic_retries"].(int)
 			httpv2.Test.SchedulingStrategy = http["scheduling_strategy"].(string)
 			httpv2.Test.Active = http["active"].(bool)
 			httpv2.Test.RequestMethod = http["request_method"].(string)
@@ -1191,6 +1202,7 @@ func buildPortCheckV2Data(d *schema.ResourceData) sc2.PortCheckV2Input {
 			portv2.Test.Host = port["host"].(string)
 			portv2.Test.LocationIds = buildLocationIdData(port["location_ids"].([]interface{}))
 			portv2.Test.Frequency = port["frequency"].(int)
+			portv2.Test.Automaticretries = port["automatic_retries"].(int)
 			portv2.Test.SchedulingStrategy = port["scheduling_strategy"].(string)
 			portv2.Test.Active = port["active"].(bool)
 			portv2.Test.Customproperties = buildCustomPropertiesData(port["custom_properties"].(*schema.Set))

--- a/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/common_models.go
+++ b/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/common_models.go
@@ -150,14 +150,24 @@ type Tests []struct {
 	Type               string             `json:"type"`
 	Updatedat          time.Time          `json:"updatedAt"`
 	Customproperties   []CustomProperties `json:"customProperties"`
+	Lastrunstatus      string             `json:"lastRunStatus"`
+	Lastrunat          time.Time          `json:"lastRunAt"`
+	Automaticretries   int                `json:"automaticRetries"`
 }
 
 type GetChecksV2Options struct {
-	TestType string `json:"testType"`
-	PerPage  int    `json:"perPage"`
-	Page     int    `json:"page"`
-	Search   string `json:"search"`
-	OrderBy  string `json:"orderBy"`
+	TestType           string             `json:"testType"`
+	PerPage            int                `json:"perPage"`
+	Page               int                `json:"page"`
+	Search             string             `json:"search"`
+	OrderBy            string             `json:"orderBy"`
+	Active             *bool              `json:"active"`
+	CustomProperties   []CustomProperties `json:"customProperties"`
+	Frequencies        []int              `json:"frequencies"`
+	LastRunStatus      []string           `json:"lastRunStatus"`
+	LocationIds        []string           `json:"locationIds"`
+	SchedulingStrategy string             `json:"schedulingStrategy"`
+	TestTypes          []string           `json:"testTypes"`
 }
 
 type Errors []struct {
@@ -251,6 +261,9 @@ type PortCheckV2Response struct {
 		Host               string             `json:"host"`
 		Port               int                `json:"port"`
 		Customproperties   []CustomProperties `json:"customProperties"`
+		Lastrunstatus      string             `json:"lastRunStatus"`
+		Lastrunat          time.Time          `json:"lastRunAt"`
+		Automaticretries   int                `json:"automaticRetries"`
 	} `json:"test"`
 }
 
@@ -267,6 +280,7 @@ type PortCheckV2Input struct {
 		SchedulingStrategy string             `json:"schedulingStrategy"`
 		Active             bool               `json:"active"`
 		Customproperties   []CustomProperties `json:"customProperties"`
+		Automaticretries   int                `json:"automaticRetries"`
 	} `json:"test"`
 }
 
@@ -290,6 +304,10 @@ type HttpCheckV2Response struct {
 		HttpHeaders        []HttpHeaders      `json:"headers,omitempty"`
 		Validations        []Validations      `json:"validations"`
 		Customproperties   []CustomProperties `json:"customProperties"`
+		Lastrunstatus      string             `json:"lastRunStatus"`
+		Lastrunat          time.Time          `json:"lastRunAt"`
+		Automaticretries   int                `json:"automaticRetries"`
+    Port               int                `json:"port"`
 	} `json:"test"`
 }
 
@@ -310,6 +328,8 @@ type HttpCheckV2Input struct {
 		HttpHeaders        []HttpHeaders      `json:"headers,omitempty"`
 		Validations        []Validations      `json:"validations"`
 		Customproperties   []CustomProperties `json:"customProperties"`
+		Automaticretries   int                `json:"automaticRetries"`
+    Port               int                `json:"port"`
 	} `json:"test"`
 }
 
@@ -323,6 +343,7 @@ type ApiCheckV2Input struct {
 		Requests           []Requests         `json:"requests"`
 		Schedulingstrategy string             `json:"schedulingStrategy"`
 		Customproperties   []CustomProperties `json:"customProperties"`
+		Automaticretries   int                `json:"automaticRetries"`
 	} `json:"test"`
 }
 
@@ -340,6 +361,9 @@ type ApiCheckV2Response struct {
 		Type               string             `json:"type,omitempty"`
 		Updatedat          time.Time          `json:"updatedAt,omitempty"`
 		Customproperties   []CustomProperties `json:"customProperties"`
+		Lastrunstatus      string             `json:"lastRunStatus"`
+		Lastrunat          time.Time          `json:"lastRunAt"`
+		Automaticretries   int                `json:"automaticRetries"`
 	}
 }
 
@@ -356,6 +380,7 @@ type BrowserCheckV2Input struct {
 		Active             bool           `json:"active"`
 		Advancedsettings   `json:"advancedSettings,omitempty"`
 		Customproperties   []CustomProperties `json:"customProperties"`
+		Automaticretries   int                `json:"automaticRetries"`
 	} `json:"test"`
 }
 
@@ -374,6 +399,9 @@ type BrowserCheckV2Response struct {
 		Type               string             `json:"type"`
 		Updatedat          time.Time          `json:"updatedAt"`
 		Customproperties   []CustomProperties `json:"customProperties"`
+		Lastrunstatus      string             `json:"lastRunStatus"`
+		Lastrunat          time.Time          `json:"lastRunAt"`
+		Automaticretries   int                `json:"automaticRetries"`
 	} `json:"test"`
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -175,7 +175,7 @@ github.com/oklog/run
 # github.com/splunk/syntheticsclient v1.0.3
 ## explicit; go 1.14
 github.com/splunk/syntheticsclient/syntheticsclient
-# github.com/splunk/syntheticsclient/v2 v2.0.5
+# github.com/splunk/syntheticsclient/v2 v2.0.7
 ## explicit; go 1.14
 github.com/splunk/syntheticsclient/v2/syntheticsclientv2
 # github.com/vmihailenco/msgpack v4.0.4+incompatible


### PR DESCRIPTION
This adds automatic retries to the synthetics terraform provider. 

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are expected for bug fixes and features. -->
Resolves SYN-3741

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* `automatic_retries` defaulted to 0

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Users can set automatic retries to either 1 or 0

### Pull request checklist 
- [ ] Acceptance Tests have been updated, run (`make testacc`), and pasted in this PR (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

#### Acceptance Test Output
<!-- Please paste the results of acceptance tests `make testacc` in the codeblock here. -->
I tried to run these locally, but got a bunch of unauthorized errors. I am guessing there is a special account that is needed for the test suite?

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [x] No

----
