### PR TITLE
update regex for custom properties. update docs.

### DIFF
--- a/docs/resources/create_api_check_v2.md
+++ b/docs/resources/create_api_check_v2.md
@@ -168,7 +168,7 @@ Required:
 Optional:
 
 - `custom_properties` (Block Set) (see [below for nested schema](#nestedblock--test--custom_properties))
-- `requests` (Block List) (see [below for nested schema](#nestedblock--test--requests))
+- `requests` (Block List) Unique elements of a given request. See official [API documentation](https://dev.splunk.com/observability/reference/api/synthetics_api_tests/latest#endpoint-createapitest) as the source of truth for descriptions and options for these values. (see [below for nested schema](#nestedblock--test--requests))
 - `scheduling_strategy` (String)
 
 <a id="nestedblock--test--custom_properties"></a>

--- a/docs/resources/create_browser_check_v2.md
+++ b/docs/resources/create_browser_check_v2.md
@@ -254,7 +254,7 @@ Optional:
 
 Required:
 
-- `steps` (Block List, Min: 1) (see [below for nested schema](#nestedblock--test--transactions--steps))
+- `steps` (Block List, Min: 1) Unique steps for the transaction. See official [API documentation](https://dev.splunk.com/observability/reference/api/synthetics_browser/latest#endpoint-createbrowsertest) as the source of truth for descriptions and options for these values. (see [below for nested schema](#nestedblock--test--transactions--steps))
 
 Optional:
 

--- a/docs/resources/create_location_v2.md
+++ b/docs/resources/create_location_v2.md
@@ -17,7 +17,6 @@ resource "synthetics_create_location_v2" "location_v2_foo" {
   location {
     id = "private-aws-awesome-east"
     label = "awesome aws east location"
-    country = "IE"
   }    
 }
 ```

--- a/synthetics/resource_api_check_v2.go
+++ b/synthetics/resource_api_check_v2.go
@@ -66,6 +66,7 @@ func resourceApiCheckV2() *schema.Resource {
 						"requests": {
 							Type:     schema.TypeList,
 							Optional: true,
+							Description: "Unique elements of a given request. See official [API documentation](https://dev.splunk.com/observability/reference/api/synthetics_api_tests/latest#endpoint-createapitest) as the source of truth for descriptions and options for these values.",
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"configuration": {
@@ -202,12 +203,12 @@ func resourceApiCheckV2() *schema.Resource {
 									"key": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]\w{1,128}$`), "custom_properties key must start with a letter and only consist of alphanumeric and underscore characters with no whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z](\w|-|_){1,128}$`), "custom_properties key must start with a letter and only consist of alphanumeric and underscore characters with no whitespace"),
 									},
 									"value": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\w{1,256}$`), "custom_properties value can only consist of alphanumeric and underscore characters with no whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9](\w|_){1,128}$`), "custom_properties value can only consist of alphanumeric and underscore characters with no whitespace"),
 									},
 								},
 							},

--- a/synthetics/resource_browser_check_v2.go
+++ b/synthetics/resource_browser_check_v2.go
@@ -193,6 +193,7 @@ func resourceBrowserCheckV2() *schema.Resource {
 									"steps": {
 										Type:     schema.TypeList,
 										Required: true,
+										Description: "Unique steps for the transaction. See official [API documentation](https://dev.splunk.com/observability/reference/api/synthetics_browser/latest#endpoint-createbrowsertest) as the source of truth for descriptions and options for these values.",
 										Elem: &schema.Resource{
 											Schema: map[string]*schema.Schema{
 												"name": {
@@ -271,12 +272,12 @@ func resourceBrowserCheckV2() *schema.Resource {
 									"key": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]\w{1,128}$`), "custom_properties key must start with a letter and only consist of alphanumeric and underscore characters with no whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z](\w|-|_){1,128}$`), "custom_properties key must start with a letter and only consist of alphanumeric and underscore characters with no whitespace"),
 									},
 									"value": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\w{1,256}$`), "custom_properties value can only consist of alphanumeric and underscore characters with no whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9](\w|_){1,128}$`), "custom_properties value can only consist of alphanumeric and underscore characters with no whitespace"),
 									},
 								},
 							},

--- a/synthetics/resource_http_check_v2.go
+++ b/synthetics/resource_http_check_v2.go
@@ -176,12 +176,12 @@ func resourceHttpCheckV2() *schema.Resource {
 									"key": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]\w{1,128}$`), "custom_properties key must start with a letter and only consist of alphanumeric and underscore characters with no whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z](\w|-|_){1,128}$`), "custom_properties key must start with a letter and only consist of alphanumeric and underscore characters with no whitespace"),
 									},
 									"value": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\w{1,256}$`), "custom_properties value can only consist of alphanumeric and underscore characters with no whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9](\w|_){1,128}$`), "custom_properties value can only consist of alphanumeric and underscore characters with no whitespace"),
 									},
 								},
 							},

--- a/synthetics/resource_port_check_v2.go
+++ b/synthetics/resource_port_check_v2.go
@@ -108,12 +108,12 @@ func resourcePortCheckV2() *schema.Resource {
 									"key": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]\w{1,128}$`), "custom_properties key must start with a letter and only consist of alphanumeric and underscore characters with no whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z](\w|-|_){1,128}$`), "custom_properties key must start with a letter and only consist of alphanumeric and underscore characters with no whitespace"),
 									},
 									"value": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^\w{1,256}$`), "custom_properties value can only consist of alphanumeric and underscore characters with no whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9](\w|_){1,128}$`), "custom_properties value can only consist of alphanumeric and underscore characters with no whitespace"),
 									},
 								},
 							},


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are expected for bug fixes and features. -->
Resolves #39 
Addresses #40 

- Adds doc links to the API for source of truth on settings for steps, requests, transactions
- Addresses docs issue where `country` was shown as an allowed attribute on `locations`
- Fixes regexes for custom properties on checks to include `_` and `-` characters

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Custom properties would not accept as valid entries with `_` or `-` characters

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Custom properties now accept valid entries with `_` or `-` characters

### Pull request checklist 
- [X] Acceptance Tests have been updated, run (`make testacc`), and pasted in this PR (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)

#### Acceptance Test Output
<!-- Please paste the results of acceptance tests `make testacc` in the codeblock here. -->
```
terraform-provider-synthetics-fork 12:57> make testacc                                            
TF_ACC=1 go test $(go list ./... | grep -v 'vendor')  -timeout 120m   | sed '/X-Sf-Token/d'
?       github.com/splunk/terraform-provider-synthetics [no test files]
ok      github.com/splunk/terraform-provider-synthetics/synthetics      38.660s
```

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [X] No

----
