### PR TITLE
Add collect interactive metrics to browser data source

### DIFF
--- a/synthetics/data_source_browsercheck_v2.go
+++ b/synthetics/data_source_browsercheck_v2.go
@@ -173,6 +173,10 @@ func dataSourceBrowserCheckV2() *schema.Resource {
 										Type:     schema.TypeBool,
 										Computed: true,
 									},
+									"collect_interactive_metrics": {
+										Type:     schema.TypeBool,
+										Computed: true,
+									},
 								},
 							},
 						},


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are expected for bug fixes and features. -->
Resolves #46 
----

### Before the change?
browser check data source could not be used

### After the change?
browser data source works as expected, see line with `+ collect_interactive_metrics = true` below:

```
  + browserData = {
      + id   = "12654"
      + test = [
          + {
              + active                = false
              + advanced_settings     = [
                  + {
                      + authentication              = []
                      + collect_interactive_metrics = true
                      + cookies                     = []
                      + headers                     = []
                      + host_overrides              = []
                      + user_agent                  = ""
                      + verify_certificates         = true
                    },
                ]
              + business_transactions = []
              + created_at            = "2024-05-08 08:40:22.323 +0000 UTC"
              + custom_properties     = []
              + device                = [
                  + {
                      + id                 = 1
                      + label              = "Default Desktop"
                      + network_connection = [
                          + {
                              + description        = "Unthrottled"
                              + download_bandwidth = 0
                              + latency            = 0
                              + packet_loss        = 0
                              + upload_bandwidth   = 0
                            },
                        ]
                      + user_agent         = "Mozilla/5.0 (X11; Linux x86_64; Splunk Synthetics) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.5845.96 Safari/537.36"
                      + viewport_height    = 768
                      + viewport_width     = 1366
                    },
                ]
              + frequency             = 5
              + id                    = 12654
              + last_run_at           = ""
              + last_run_status       = "pending"
              + location_ids          = [
                  + "aws-eu-central-1",
                  + "aws-eu-central-2",
                  + "aws-eu-south-2",
                  + "aws-eu-west-3",
                ]
              + name                  = "browser test"
              + scheduling_strategy   = "round_robin"
              + transactions          = [
                  + {
                      + name  = "New synthetic transaction"
                      + steps = [
                          + {
                              + action               = ""
                              + duration             = 0
                              + name                 = "New step"
                              + option_selector      = ""
                              + option_selector_type = ""
                              + options              = []
                              + selector             = ""
                              + selector_type        = ""
                              + type                 = "go_to_url"
                              + url                  = "https://show.splunk.com"
                              + value                = ""
                              + variable_name        = ""
                              + wait_for_nav         = false
                            },
                        ]
                    },
                ]
              + type                  = "browser"
              + updated_at            = "2024-05-08 08:40:22.328 +0000 UTC"
            },
        ]
    }
```

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [ X ] No

----
