### PR TITLE
SYN-4088: Adds wait_for_nav_timeout and max_wait_time to browser steps

### DIFF
--- a/docs/data-sources/browser_v2_check.md
+++ b/docs/data-sources/browser_v2_check.md
@@ -145,16 +145,8 @@ Read-Only:
 - `value` (String)
 - `variable_name` (String)
 - `wait_for_nav` (Boolean)
-
-<a id="nestedobjatt--test--business_transactions--steps--options"></a>
-### Nested Schema for `test.business_transactions.steps.wait_for_nav`
-
-Read-Only:
-
-- `url` (String)
-
-
-
+- `wait_for_nav_timeout` (Number)
+- `max_wait_time` (Number)
 
 <a id="nestedatt--test--device"></a>
 ### Nested Schema for `test.device`
@@ -207,12 +199,5 @@ Read-Only:
 - `value` (String)
 - `variable_name` (String)
 - `wait_for_nav` (Boolean)
-
-<a id="nestedobjatt--test--transactions--steps--options"></a>
-### Nested Schema for `test.transactions.steps.wait_for_nav`
-
-Read-Only:
-
-- `url` (String)
-
-
+- `wait_for_nav_timeout` (Number)
+- `max_wait_time` (Number)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/splunk/syntheticsclient v1.0.3
-	github.com/splunk/syntheticsclient/v2 v2.0.8
+	github.com/splunk/syntheticsclient/v2 v2.0.9
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -180,6 +180,8 @@ github.com/splunk/syntheticsclient/v2 v2.0.7 h1:cfZPoIW/tX/5DiKLv+OZsiYiPGHYT1j5
 github.com/splunk/syntheticsclient/v2 v2.0.7/go.mod h1:xP4ikfSyA0eVyI72sa11hi9yUDBaQhB5mtW6QSClaWw=
 github.com/splunk/syntheticsclient/v2 v2.0.8 h1:QkliQW7Z+u7YIYsVc0JgudZQ/SItoMXBCa7oC0sZPhU=
 github.com/splunk/syntheticsclient/v2 v2.0.8/go.mod h1:xP4ikfSyA0eVyI72sa11hi9yUDBaQhB5mtW6QSClaWw=
+github.com/splunk/syntheticsclient/v2 v2.0.9 h1:bqc43RIZzYOL5IajdJmmw4ck3clHuVy3/rZyH1H11d4=
+github.com/splunk/syntheticsclient/v2 v2.0.9/go.mod h1:xP4ikfSyA0eVyI72sa11hi9yUDBaQhB5mtW6QSClaWw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/synthetics/data_source_browsercheck_v2.go
+++ b/synthetics/data_source_browsercheck_v2.go
@@ -238,6 +238,14 @@ func dataSourceBrowserCheckV2() *schema.Resource {
 													Type:     schema.TypeBool,
 													Optional: true,
 												},
+												"wait_for_nav_timeout": {
+													Type:     schema.TypeInt,
+													Optional: true,
+												},
+												"max_wait_time": {
+													Type:     schema.TypeInt,
+													Optional: true,
+												},
 												"options": {
 													Type:     schema.TypeSet,
 													Computed: true,
@@ -315,6 +323,14 @@ func dataSourceBrowserCheckV2() *schema.Resource {
 													Optional: true,
 												},
 												"duration": {
+													Type:     schema.TypeInt,
+													Optional: true,
+												},
+												"wait_for_nav_timeout": {
+													Type:     schema.TypeInt,
+													Optional: true,
+												},
+												"max_wait_time": {
 													Type:     schema.TypeInt,
 													Optional: true,
 												},

--- a/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/common_models.go
+++ b/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/common_models.go
@@ -77,6 +77,8 @@ type StepsV2 struct {
 	URL                string  `json:"url,omitempty"`
 	Action             string  `json:"action,omitempty"`
 	WaitForNav         bool    `json:"waitForNav"`
+	WaitForNavTimeout  int     `json:"waitForNavTimeout"`
+	MaxWaitTime        int     `json:"maxWaitTime"`
 	SelectorType       string  `json:"selectorType,omitempty"`
 	Selector           string  `json:"selector,omitempty"`
 	OptionSelectorType string  `json:"optionSelectorType,omitempty"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -175,7 +175,7 @@ github.com/oklog/run
 # github.com/splunk/syntheticsclient v1.0.3
 ## explicit; go 1.14
 github.com/splunk/syntheticsclient/syntheticsclient
-# github.com/splunk/syntheticsclient/v2 v2.0.8
+# github.com/splunk/syntheticsclient/v2 v2.0.9
 ## explicit; go 1.14
 github.com/splunk/syntheticsclient/v2/syntheticsclientv2
 # github.com/vmihailenco/msgpack v4.0.4+incompatible


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are expected for bug fixes and features. -->
Resolves https://splunk.atlassian.net/browse/SYN-4088. When I submitted https://github.com/splunk/syntheticsclient/pull/25, I thought it was to change the terraform provider, so this is what this MR is :).

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Assert steps on browser steps did not allow you to configure a wait time (wait for x seconds for an element to appear). And steps with navigation did not allow you to configure how long to wait for a navigation event.


### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Adds max_wait_time and wait_for_nav_timeout to browser steps, allowing users to specify wait times. See https://splunk.enterprise.slack.com/docs/T024FQ3UW/F07BZ0A7TK6 for a small demo.

### Pull request checklist 
- [ ] Acceptance Tests have been updated, run (`make testacc`), and pasted in this PR (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

#### Acceptance Test Output
<!-- Please paste the results of acceptance tests `make testacc` in the codeblock here. -->
```

```

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [x] No

----
