### PR TITLE
SYN-4078: add createdBy and updatedBy to /tests responses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/splunk/syntheticsclient v1.0.3
-	github.com/splunk/syntheticsclient/v2 v2.0.9
+	github.com/splunk/syntheticsclient/v2 v2.0.10
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -182,6 +182,8 @@ github.com/splunk/syntheticsclient/v2 v2.0.8 h1:QkliQW7Z+u7YIYsVc0JgudZQ/SItoMXB
 github.com/splunk/syntheticsclient/v2 v2.0.8/go.mod h1:xP4ikfSyA0eVyI72sa11hi9yUDBaQhB5mtW6QSClaWw=
 github.com/splunk/syntheticsclient/v2 v2.0.9 h1:bqc43RIZzYOL5IajdJmmw4ck3clHuVy3/rZyH1H11d4=
 github.com/splunk/syntheticsclient/v2 v2.0.9/go.mod h1:xP4ikfSyA0eVyI72sa11hi9yUDBaQhB5mtW6QSClaWw=
+github.com/splunk/syntheticsclient/v2 v2.0.10 h1:Hv8nlP2WIXDNQzhRz0L6gcsUDoB5mKptdOHQyakAkEw=
+github.com/splunk/syntheticsclient/v2 v2.0.10/go.mod h1:xP4ikfSyA0eVyI72sa11hi9yUDBaQhB5mtW6QSClaWw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/synthetics/data_source_apicheck_v2.go
+++ b/synthetics/data_source_apicheck_v2.go
@@ -45,6 +45,10 @@ func dataSourceApiCheckV2() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"created_by": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"device": {
 							Type:     schema.TypeSet,
 							Computed: true,
@@ -250,6 +254,10 @@ func dataSourceApiCheckV2() *schema.Resource {
 							Computed: true,
 						},
 						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_by": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},

--- a/synthetics/data_source_browsercheck_v2.go
+++ b/synthetics/data_source_browsercheck_v2.go
@@ -57,7 +57,15 @@ func dataSourceBrowserCheckV2() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"created_by": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_by": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},

--- a/synthetics/data_source_httpcheck_v2.go
+++ b/synthetics/data_source_httpcheck_v2.go
@@ -58,7 +58,15 @@ func dataSourceHttpCheckV2() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"created_by": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_by": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},

--- a/synthetics/data_source_portcheck_v2.go
+++ b/synthetics/data_source_portcheck_v2.go
@@ -57,7 +57,15 @@ func dataSourcePortCheckV2() *schema.Resource {
 							Type:     schema.TypeString,
 							Computed: true,
 						},
+						"created_by": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"updated_at": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"updated_by": {
 							Type:     schema.TypeString,
 							Computed: true,
 						},

--- a/synthetics/structures.go
+++ b/synthetics/structures.go
@@ -96,11 +96,11 @@ func flattenApiV2Data(checkApiV2 *sc2.ApiCheckV2Response) []interface{} {
 	}
 
 	if checkApiV2.Test.Createdby != "" {
-		apiV2["created_by"] = checkApiV2.Test.Createdby.String()
+		apiV2["created_by"] = checkApiV2.Test.Createdby
 	}
 
 	if checkApiV2.Test.Updatedby != "" {
-		apiV2["updated_by"] = checkApiV2.Test.Updatedby.String()
+		apiV2["updated_by"] = checkApiV2.Test.Updatedby
 	}
 
 	if checkApiV2.Test.Lastrunat.IsZero() {
@@ -491,11 +491,11 @@ func flattenBrowserV2Data(checkBrowserV2 *sc2.BrowserCheckV2Response) []interfac
 	}
 
 	if checkBrowserV2.Test.Createdby != "" {
-		browserV2["created_by"] = checkBrowserV2.Test.Createdby.String()
+		browserV2["created_by"] = checkBrowserV2.Test.Createdby
 	}
 
 	if checkBrowserV2.Test.Updatedby != "" {
-		browserV2["updated_by"] = checkBrowserV2.Test.Updatedby.String()
+		browserV2["updated_by"] = checkBrowserV2.Test.Updatedby
 	}
 
 	if checkBrowserV2.Test.Lastrunat.IsZero() {
@@ -634,11 +634,11 @@ func flattenHttpV2Data(checkHttpV2 *sc2.HttpCheckV2Response) []interface{} {
 	}
 
 	if checkHttpV2.Test.Createdby != "" {
-		httpV2["created_by"] = checkHttpV2.Test.Createdby.String()
+		httpV2["created_by"] = checkHttpV2.Test.Createdby
 	}
 
 	if checkHttpV2.Test.Updatedby != "" {
-		httpV2["updated_by"] = checkHttpV2.Test.Updatedby.String()
+		httpV2["updated_by"] = checkHttpV2.Test.Updatedby
 	}
 
 	if checkHttpV2.Test.Lastrunat.IsZero() {
@@ -769,11 +769,11 @@ func flattenPortCheckV2Data(checkPortV2 *sc2.PortCheckV2Response) []interface{} 
 	}
 
 	if checkPortV2.Test.Createdby != "" {
-		portV2["created_by"] = checkPortV2.Test.Createdby.String()
+		portV2["created_by"] = checkPortV2.Test.Createdby
 	}
 
 	if checkPortV2.Test.Updatedby != "" {
-		portV2["updated_by"] = checkPortV2.Test.Updatedby.String()
+		portV2["updated_by"] = checkPortV2.Test.Updatedby
 	}
 
 	if checkPortV2.Test.Lastrunat.IsZero() {

--- a/synthetics/structures.go
+++ b/synthetics/structures.go
@@ -95,6 +95,14 @@ func flattenApiV2Data(checkApiV2 *sc2.ApiCheckV2Response) []interface{} {
 		apiV2["updated_at"] = checkApiV2.Test.Updatedat.String()
 	}
 
+	if checkApiV2.Test.Createdby != "" {
+		apiV2["created_by"] = checkApiV2.Test.Createdby.String()
+	}
+
+	if checkApiV2.Test.Updatedby != "" {
+		apiV2["updated_by"] = checkApiV2.Test.Updatedby.String()
+	}
+
 	if checkApiV2.Test.Lastrunat.IsZero() {
 	} else {
 		apiV2["last_run_at"] = checkApiV2.Test.Lastrunat.String()
@@ -482,6 +490,14 @@ func flattenBrowserV2Data(checkBrowserV2 *sc2.BrowserCheckV2Response) []interfac
 		browserV2["updated_at"] = checkBrowserV2.Test.Updatedat.String()
 	}
 
+	if checkBrowserV2.Test.Createdby != "" {
+		browserV2["created_by"] = checkBrowserV2.Test.Createdby.String()
+	}
+
+	if checkBrowserV2.Test.Updatedby != "" {
+		browserV2["updated_by"] = checkBrowserV2.Test.Updatedby.String()
+	}
+
 	if checkBrowserV2.Test.Lastrunat.IsZero() {
 	} else {
 		browserV2["last_run_at"] = checkBrowserV2.Test.Lastrunat.String()
@@ -617,6 +633,14 @@ func flattenHttpV2Data(checkHttpV2 *sc2.HttpCheckV2Response) []interface{} {
 		httpV2["updated_at"] = checkHttpV2.Test.UpdatedAt.String()
 	}
 
+	if checkHttpV2.Test.Createdby != "" {
+		httpV2["created_by"] = checkHttpV2.Test.Createdby.String()
+	}
+
+	if checkHttpV2.Test.Updatedby != "" {
+		httpV2["updated_by"] = checkHttpV2.Test.Updatedby.String()
+	}
+
 	if checkHttpV2.Test.Lastrunat.IsZero() {
 	} else {
 		httpV2["last_run_at"] = checkHttpV2.Test.Lastrunat.String()
@@ -742,6 +766,14 @@ func flattenPortCheckV2Data(checkPortV2 *sc2.PortCheckV2Response) []interface{} 
 	if checkPortV2.Test.UpdatedAt.IsZero() {
 	} else {
 		portV2["updated_at"] = checkPortV2.Test.UpdatedAt.String()
+	}
+
+	if checkPortV2.Test.Createdby != "" {
+		portV2["created_by"] = checkPortV2.Test.Createdby.String()
+	}
+
+	if checkPortV2.Test.Updatedby != "" {
+		portV2["updated_by"] = checkPortV2.Test.Updatedby.String()
 	}
 
 	if checkPortV2.Test.Lastrunat.IsZero() {

--- a/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/common_models.go
+++ b/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/common_models.go
@@ -155,6 +155,8 @@ type Tests []struct {
 	Lastrunstatus      string             `json:"lastRunStatus"`
 	Lastrunat          time.Time          `json:"lastRunAt"`
 	Automaticretries   int                `json:"automaticRetries"`
+	Createdby          string             `json:"createdBy"`
+	Updatedby          string             `json:"updatedBy"`
 }
 
 type GetChecksV2Options struct {
@@ -305,6 +307,8 @@ type PortCheckV2Response struct {
 		Lastrunstatus      string             `json:"lastRunStatus"`
 		Lastrunat          time.Time          `json:"lastRunAt"`
 		Automaticretries   int                `json:"automaticRetries"`
+		Createdby          string             `json:"createdBy"`
+		Updatedby          string             `json:"updatedBy"`
 	} `json:"test"`
 }
 
@@ -349,6 +353,8 @@ type HttpCheckV2Response struct {
 		Lastrunat          time.Time          `json:"lastRunAt"`
 		Automaticretries   int                `json:"automaticRetries"`
 		Port               int                `json:"port"`
+		Createdby          string             `json:"createdBy"`
+		Updatedby          string             `json:"updatedBy"`
 	} `json:"test"`
 }
 
@@ -405,6 +411,8 @@ type ApiCheckV2Response struct {
 		Lastrunstatus      string             `json:"lastRunStatus"`
 		Lastrunat          time.Time          `json:"lastRunAt"`
 		Automaticretries   int                `json:"automaticRetries"`
+		Createdby          string             `json:"createdBy"`
+		Updatedby          string             `json:"updatedBy"`
 	}
 }
 
@@ -443,6 +451,8 @@ type BrowserCheckV2Response struct {
 		Lastrunstatus      string             `json:"lastRunStatus"`
 		Lastrunat          time.Time          `json:"lastRunAt"`
 		Automaticretries   int                `json:"automaticRetries"`
+		Createdby          string             `json:"createdBy"`
+		Updatedby          string             `json:"updatedBy"`
 	} `json:"test"`
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -175,7 +175,7 @@ github.com/oklog/run
 # github.com/splunk/syntheticsclient v1.0.3
 ## explicit; go 1.14
 github.com/splunk/syntheticsclient/syntheticsclient
-# github.com/splunk/syntheticsclient/v2 v2.0.9
+# github.com/splunk/syntheticsclient/v2 v2.0.10
 ## explicit; go 1.14
 github.com/splunk/syntheticsclient/v2/syntheticsclientv2
 # github.com/vmihailenco/msgpack v4.0.4+incompatible


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are expected for bug fixes and features. -->
Resolves https://splunk.atlassian.net/browse/SYN-4078

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* doesn't include fields `createdBy` and `updatedBy` in /tests responses

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* adds `createdBy` and `updatedBy` to /tests responses

### Pull request checklist 
- [ ] Acceptance Tests have been updated, run (`make testacc`), and pasted in this PR (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

#### Acceptance Test Output
<!-- Please paste the results of acceptance tests `make testacc` in the codeblock here. -->
```

```

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [x] No

----
