### PR TITLE
Behavior for waitNavTimeout migration 

### DIFF
--- a/synthetics/resource_browser_check_v2.go
+++ b/synthetics/resource_browser_check_v2.go
@@ -248,6 +248,8 @@ func resourceBrowserCheckV2() *schema.Resource {
 												"wait_for_nav_timeout": {
 													Type:     schema.TypeInt,
 													Optional: true,
+													Default: 1000,
+													ValidateFunc: validation.IntAtLeast(1),
 												},
 												"max_wait_time": {
 													Type:     schema.TypeInt,

--- a/synthetics/resource_browser_check_v2_test.go
+++ b/synthetics/resource_browser_check_v2_test.go
@@ -94,7 +94,7 @@ resource "synthetics_create_browser_check_v2" "browser_v2_foo_check" {
         selector_type        = "id"
         type                 = "enter_value"
         value                = "{{env.acceptance-variable-terraform-test}}"
-        wait_for_nav_timeout = 50
+        wait_for_nav_timeout = null
       }
       steps {
         name                 = "03 click"
@@ -102,7 +102,7 @@ resource "synthetics_create_browser_check_v2" "browser_v2_foo_check" {
         selector_type        = "id"
         type                 = "click_element"
         wait_for_nav         = true
-        wait_for_nav_timeout = 2000
+        wait_for_nav_timeout = 2022
       }
       steps {
         name                 = "04 accept---Alert"
@@ -115,8 +115,7 @@ resource "synthetics_create_browser_check_v2" "browser_v2_foo_check" {
         selector             = "textzz"
         selector_type        = "id"
         type                 = "select_option"
-        wait_for_nav         = false
-        wait_for_nav_timeout = 50
+        wait_for_nav         = true
       }
     }
     transactions {
@@ -251,14 +250,14 @@ resource "synthetics_create_browser_check_v2" "browser_v2_foo_check" {
         value                = "sdasds"
         variable_name        = "{{env.terraform-test-foo-301}}"
         wait_for_nav         = true
-        wait_for_nav_timeout = 2000
+        wait_for_nav_timeout = 2022
       }
       steps {
         name                 = "010 Run JS"
         type                 = "run_javascript"
         value                = "beeeeeeep"
         wait_for_nav         = true
-        wait_for_nav_timeout = 2000
+        wait_for_nav_timeout = 2022
       }
     }
     transactions {
@@ -333,8 +332,10 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.name", "First Synthetic transaction"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.0.name", "01 Go to URL"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.0.type", "go_to_url"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.0.url", "https://www.splunk.com"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.0.wait_for_nav_timeout", "1000"),
+          resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.0.url", "https://www.splunk.com"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.1.name", "02 fill in fieldz"),
+          resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.1.wait_for_nav_timeout", "1000"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.1.selector", "beep"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.1.selector_type", "id"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.1.type", "enter_value"),
@@ -344,7 +345,7 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.selector_type", "id"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.type", "click_element"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.wait_for_nav", "true"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.wait_for_nav_timeout", "2000"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.wait_for_nav_timeout", "2022"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.3.name", "04 accept---Alert"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.3.type", "accept_alert"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.4.name", "05 Select-val-text"),
@@ -353,8 +354,7 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.4.selector", "textzz"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.4.selector_type", "id"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.4.type", "select_option"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.4.wait_for_nav", "false"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.4.wait_for_nav_timeout", "50"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.4.wait_for_nav", "true"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.name", "2nd Synthetic transaction"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.0.name", "Go to other URL"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.0.type", "go_to_url"),
@@ -446,12 +446,12 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.5.value", "sdasds"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.5.variable_name", "{{env.terraform-test-foo-301}}"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.5.wait_for_nav", "true"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.5.wait_for_nav_timeout", "2000"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.5.wait_for_nav_timeout", "2022"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.6.name", "010 Run JS"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.6.type", "run_javascript"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.6.value", "beeeeeeep"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.6.wait_for_nav", "true"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.6.wait_for_nav_timeout", "2000"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.6.wait_for_nav_timeout", "2022"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.name", "2nd Synthetic transaction"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.0.name", "Go to other URL"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.0.type", "go_to_url"),

--- a/synthetics/structures.go
+++ b/synthetics/structures.go
@@ -965,6 +965,8 @@ func flattenStepsData(checkSteps *[]sc2.StepsV2) []interface{} {
 
 			if checkStep.WaitForNavTimeout != 0 {
 				cl["wait_for_nav_timeout"] = checkStep.WaitForNavTimeout
+			} else {
+				cl["wait_for_nav_timeout"] = 1000
 			}
 
 			if checkStep.MaxWaitTime != 0 {


### PR DESCRIPTION
This builds on #60 
Due to the API sending back a dynamic value based on another attribute setting we're having trouble getting a consistent plan. Behavior appears to be as follows:

- `waitForNav` is needed in the request body
- if `waitForNavTimeout` isn’t provided, the API uses the value from `waitForNav` to determine the timeout value. so if `true`, `waitForNavTimeout` value will be `2000`, and if it’s `false`, then `waitForNavTimeout` value will be `50`
- if `waitForNavTimeout` is provided, it just uses that and the false/true thing from `waitForNav` doesn’t matter

This can cause us to create a plan that doesn't match either `2000` or `50` correctly due to `waitForNavTimeout` not being set.

## What we're doing here.
Because we can't easily do  a check on a different attribute value and make changes to compensate at plan time we are implementing logic to set a static `waitForNavTimeout` with value of `1000` (this was  an arbitrary number) if one isn't set.

We're also adding validation to the input of `waitForNavTimeout` that it must be an int greater than zero.