### PR TITLE
SYN-4410: Do not send 0 for max_wait_time if field is not provided

### DIFF
--- a/synthetics/resource_browser_check_v2.go
+++ b/synthetics/resource_browser_check_v2.go
@@ -254,6 +254,8 @@ func resourceBrowserCheckV2() *schema.Resource {
 												"max_wait_time": {
 													Type:     schema.TypeInt,
 													Optional: true,
+                          Default: 10000,
+                          ValidateFunc: validation.IntAtLeast(1),
 												},
 												"options": {
 													Type:     schema.TypeSet,

--- a/synthetics/resource_browser_check_v2_test.go
+++ b/synthetics/resource_browser_check_v2_test.go
@@ -116,7 +116,7 @@ resource "synthetics_create_browser_check_v2" "browser_v2_foo_check" {
         selector_type        = "id"
         type                 = "select_option"
         wait_for_nav         = false
-        wait_for_nav_timeout = 0
+        wait_for_nav_timeout = 1
       }
     }
     transactions {
@@ -139,6 +139,12 @@ resource "synthetics_create_browser_check_v2" "browser_v2_foo_check" {
         selector             = "beep"
         selector_type        = "id"
         max_wait_time        = 1000
+      }
+      steps {
+        name                 = "assert element visible no max wait time"
+        type                 = "assert_element_visible"
+        selector             = "beep"
+        selector_type        = "id"
       }
     }
   }
@@ -344,7 +350,7 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.selector_type", "id"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.type", "click_element"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.wait_for_nav", "true"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.wait_for_nav_timeout", "2000"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.wait_for_nav_timeout", "50"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.3.name", "04 accept---Alert"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.3.type", "accept_alert"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.4.name", "05 Select-val-text"),
@@ -354,7 +360,7 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.4.selector_type", "id"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.4.type", "select_option"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.4.wait_for_nav", "false"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.4.wait_for_nav_timeout", "50"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.4.wait_for_nav_timeout", "1"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.name", "2nd Synthetic transaction"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.0.name", "Go to other URL"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.0.type", "go_to_url"),
@@ -370,6 +376,11 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.2.selector", "beep"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.2.selector_type", "id"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.2.max_wait_time", "1000"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.3.name", "assert element visible no max wait time"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.3.type", "assert_element_visible"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.3.selector", "beep"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.3.selector_type", "id"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.3.max_wait_time", "10000"),
 				),
 			},
 			{

--- a/synthetics/structures.go
+++ b/synthetics/structures.go
@@ -971,7 +971,9 @@ func flattenStepsData(checkSteps *[]sc2.StepsV2) []interface{} {
 
 			if checkStep.MaxWaitTime != 0 {
 				cl["max_wait_time"] = checkStep.MaxWaitTime
-			}
+			} else {
+				cl["max_wait_time"] = 10000
+      }
 
 			if checkStep.Selector != "" {
 				cl["selector"] = checkStep.Selector


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are expected for bug fixes and features. -->
Resolves SYN-4410

----

### Before the change?
* If a test config did not specify `max_wait_time`, the provider will send `0` as a default value, breaking tests.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* If a test config does not specify `max_wait_time`, the provider will send the default, which is `10000` to the API. If `max_wait_time` is provided, it will use that instead.

### Pull request checklist 
- [x] Acceptance Tests have been updated, run (`make testacc`), and pasted in this PR (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

#### Acceptance Test Output

```
$ TF_ACC=1 TF_LOG=INFO go test ./synthetics/... -run TestAccCreateUpdateBrowserCheckV2
ok      github.com/splunk/terraform-provider-synthetics/synthetics      (cached)
```

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [x] No

----
