### PR TITLE
SYN-4475: Adds chrome flags to provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/splunk/syntheticsclient v1.0.3
-	github.com/splunk/syntheticsclient/v2 v2.0.10
+	github.com/splunk/syntheticsclient/v2 v2.0.12
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -184,6 +184,8 @@ github.com/splunk/syntheticsclient/v2 v2.0.9 h1:bqc43RIZzYOL5IajdJmmw4ck3clHuVy3
 github.com/splunk/syntheticsclient/v2 v2.0.9/go.mod h1:xP4ikfSyA0eVyI72sa11hi9yUDBaQhB5mtW6QSClaWw=
 github.com/splunk/syntheticsclient/v2 v2.0.10 h1:Hv8nlP2WIXDNQzhRz0L6gcsUDoB5mKptdOHQyakAkEw=
 github.com/splunk/syntheticsclient/v2 v2.0.10/go.mod h1:xP4ikfSyA0eVyI72sa11hi9yUDBaQhB5mtW6QSClaWw=
+github.com/splunk/syntheticsclient/v2 v2.0.12 h1:GfWNnpNxkgBYmkXghpo6IkbcInnKgZeaMMfqufgvaKQ=
+github.com/splunk/syntheticsclient/v2 v2.0.12/go.mod h1:xP4ikfSyA0eVyI72sa11hi9yUDBaQhB5mtW6QSClaWw=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/synthetics/data_source_browsercheck_v2.go
+++ b/synthetics/data_source_browsercheck_v2.go
@@ -109,6 +109,22 @@ func dataSourceBrowserCheckV2() *schema.Resource {
 											},
 										},
 									},
+                  "chrome_flags": {
+                    Type:     schema.TypeSet,
+                    Computed: true,
+                    Elem: &schema.Resource{
+                      Schema: map[string]*schema.Schema{
+                        "name": {
+                          Type:     schema.TypeString,
+                          Computed: true,
+                        },
+                        "value": {
+                          Type:     schema.TypeString,
+                          Computed: true,
+                        },
+                      },
+                    },
+                  },
 									"cookies": {
 										Type:     schema.TypeSet,
 										Computed: true,

--- a/synthetics/resource_browser_check_v2.go
+++ b/synthetics/resource_browser_check_v2.go
@@ -111,6 +111,22 @@ func resourceBrowserCheckV2() *schema.Resource {
 											},
 										},
 									},
+                  "chrome_flags": {
+                    Type:     schema.TypeSet,
+                    Optional: true,
+                    Elem: &schema.Resource{
+                      Schema: map[string]*schema.Schema{
+                        "name": {
+                          Type:     schema.TypeString,
+                          Optional: true,
+                        },
+                        "value": {
+                          Type:     schema.TypeString,
+                          Optional: true,
+                        },
+                      },
+                    },
+                  },
 									"cookies": {
 										Type:     schema.TypeSet,
 										Optional: true,

--- a/synthetics/resource_browser_check_v2_test.go
+++ b/synthetics/resource_browser_check_v2_test.go
@@ -70,6 +70,14 @@ resource "synthetics_create_browser_check_v2" "browser_v2_foo_check" {
         domain = "zodiak.com"
         path = "/Edlesley"
       }
+      chrome_flags {
+        name = "--proxy-server"
+        value = "my-proxy-server:80"
+      }
+      chrome_flags {
+        name = "--proxy-bypass-list"
+        value = "127.0.0.1:8080"
+      }
       host_overrides {
         source = "asdasd.com"
         target = "whost.com"
@@ -200,6 +208,14 @@ resource "synthetics_create_browser_check_v2" "browser_v2_foo_check" {
         domain = "zodiak.com"
         path = "/Edlesley"
       }
+      chrome_flags {
+        name = "--proxy-server"
+        value = "foo:80"
+      }
+      chrome_flags {
+        name = "--proxy-bypass-list"
+        value = "*google.com"
+      }
       host_overrides {
         source = "asdasd.com"
         target = "whost.com"
@@ -329,6 +345,10 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.cookies.1.value", "no"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.cookies.1.domain", "zodiak.com"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.cookies.1.path", "/Edlesley"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.chrome_flags.0.name", "--proxy-bypass-list"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.chrome_flags.0.value", "127.0.0.1:8080"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.chrome_flags.1.name", "--proxy-server"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.chrome_flags.1.value", "my-proxy-server:80"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.host_overrides.0.source", "asdasd.com"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.host_overrides.0.target", "whost.com"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.host_overrides.0.keep_host_header", "false"),
@@ -419,6 +439,10 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.cookies.1.value", "no"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.cookies.1.domain", "zodiak.com"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.cookies.1.path", "/Edlesley"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.chrome_flags.0.name", "--proxy-bypass-list"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.chrome_flags.0.value", "*google.com"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.chrome_flags.1.name", "--proxy-server"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.chrome_flags.1.value", "foo:80"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.host_overrides.0.source", "asdasd.com"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.host_overrides.0.target", "whost.com"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.host_overrides.0.keep_host_header", "false"),

--- a/synthetics/structures.go
+++ b/synthetics/structures.go
@@ -1016,6 +1016,23 @@ func flattenStepsData(checkSteps *[]sc2.StepsV2) []interface{} {
 	return make([]interface{}, 0)
 }
 
+func flattenChromeFlagsData(chromeFlags []sc2.ChromeFlag) []interface{} {
+  if chromeFlags == nil {
+    return []interface{}{}
+  }
+
+  var result []interface{}
+  for _, flag := range chromeFlags {
+    flagData := map[string]interface{}{
+      "name":  flag.Name,
+      "value": flag.Value,
+    }
+    result = append(result, flagData)
+  }
+
+  return result
+}
+
 func flattenSetupData(checkSetup *[]sc2.Setup) []interface{} {
 	if checkSetup != nil {
 		cls := make([]interface{}, len(*checkSetup))
@@ -1284,6 +1301,9 @@ func flattenAdvancedSettingsData(advSettings *sc2.Advancedsettings) []interface{
 
 	HostOverRides := flattenHostOverridesData(&advSettings.HostOverrides)
 	advancedSettings["host_overrides"] = HostOverRides
+
+  ChromeFlags := flattenChromeFlagsData(advSettings.ChromeFlags)
+  advancedSettings["chrome_flags"] = ChromeFlags
 
 	return []interface{}{advancedSettings}
 }
@@ -1607,6 +1627,8 @@ func buildAdvancedSettingsData(advancedSettings *schema.Set) sc2.Advancedsetting
 		advancedSettingsData.BrowserHeaders = buildBrowserHeadersData(as_map["headers"].(*schema.Set))
 		advancedSettingsData.Cookiesv2 = buildCookiesData(as_map["cookies"].(*schema.Set))
 		advancedSettingsData.HostOverrides = buildHostOverridesData(as_map["host_overrides"].(*schema.Set))
+    advancedSettingsData.ChromeFlags = buildChromeFlagsData(as_map["chrome_flags"].(*schema.Set))
+
 	}
 	return advancedSettingsData
 }
@@ -1625,6 +1647,18 @@ func buildBrowserHeadersData(headers *schema.Set) []sc2.BrowserHeaders {
 
 	}
 	return headersList
+}
+
+func buildChromeFlagsData(d *schema.Set) []sc2.ChromeFlag {
+  var flags []sc2.ChromeFlag
+  for _, item := range d.List() {
+    data := item.(map[string]interface{})
+    flags = append(flags, sc2.ChromeFlag{
+      Name:  data["name"].(string),
+      Value: data["value"].(string),
+    })
+  }
+  return flags
 }
 
 func buildCookiesData(cookies *schema.Set) []sc2.Cookiesv2 {

--- a/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/common_models.go
+++ b/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/common_models.go
@@ -35,6 +35,7 @@ type Advancedsettings struct {
 	UserAgent                 *string          `json:"userAgent"`
 	CollectInteractiveMetrics bool             `json:"collectInteractiveMetrics"`
 	Verifycertificates        bool             `json:"verifyCertificates"`
+  ChromeFlags               []ChromeFlag     `json:"chromeFlags"` // Add this line
 }
 
 type Authentication struct {
@@ -181,6 +182,15 @@ type GetDowntimeConfigurationsV2Options struct {
 	OrderBy string   `json:"orderBy"`
 	Rule    []string `json:"rule"`
 	Status  []string `json:"status"`
+}
+
+type ChromeFlag struct {
+    Name         string `json:"name"`
+    Value        string `json:"value"`
+}
+
+type ChromeFlagsResponse struct {
+    ChromeFlags []ChromeFlag `json:"chromeFlags"`
 }
 
 type Errors []struct {

--- a/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/common_models.go
+++ b/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/common_models.go
@@ -35,7 +35,16 @@ type Advancedsettings struct {
 	UserAgent                 *string          `json:"userAgent"`
 	CollectInteractiveMetrics bool             `json:"collectInteractiveMetrics"`
 	Verifycertificates        bool             `json:"verifyCertificates"`
-  ChromeFlags               []ChromeFlag     `json:"chromeFlags"` // Add this line
+	ChromeFlags               []ChromeFlag     `json:"chromeFlags"`
+}
+
+type ChromeFlag struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type ChromeFlagsResponse struct {
+	ChromeFlags []ChromeFlag `json:"chromeFlags"`
 }
 
 type Authentication struct {
@@ -78,8 +87,8 @@ type StepsV2 struct {
 	URL                string  `json:"url,omitempty"`
 	Action             string  `json:"action,omitempty"`
 	WaitForNav         bool    `json:"waitForNav"`
-	WaitForNavTimeout  int     `json:"waitForNavTimeout"`
-	MaxWaitTime        int     `json:"maxWaitTime"`
+	WaitForNavTimeout  int     `json:"waitForNavTimeout,omitempty"`
+	MaxWaitTime        int     `json:"maxWaitTime,omitempty"`
 	SelectorType       string  `json:"selectorType,omitempty"`
 	Selector           string  `json:"selector,omitempty"`
 	OptionSelectorType string  `json:"optionSelectorType,omitempty"`
@@ -182,15 +191,6 @@ type GetDowntimeConfigurationsV2Options struct {
 	OrderBy string   `json:"orderBy"`
 	Rule    []string `json:"rule"`
 	Status  []string `json:"status"`
-}
-
-type ChromeFlag struct {
-    Name         string `json:"name"`
-    Value        string `json:"value"`
-}
-
-type ChromeFlagsResponse struct {
-    ChromeFlags []ChromeFlag `json:"chromeFlags"`
 }
 
 type Errors []struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -175,7 +175,7 @@ github.com/oklog/run
 # github.com/splunk/syntheticsclient v1.0.3
 ## explicit; go 1.14
 github.com/splunk/syntheticsclient/syntheticsclient
-# github.com/splunk/syntheticsclient/v2 v2.0.10
+# github.com/splunk/syntheticsclient/v2 v2.0.12
 ## explicit; go 1.14
 github.com/splunk/syntheticsclient/v2/syntheticsclientv2
 # github.com/vmihailenco/msgpack v4.0.4+incompatible


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are expected for bug fixes and features. -->
Resolves [SYN-4475](https://splunk.atlassian.net/browse/SYN-4475)

----

### Before the change?

* Browser configs do not support `chrome_flags`.

### After the change?

* Browser configs should support `chrome_flags`.

### Pull request checklist 
- [x] Acceptance Tests have been updated, run (`make testacc`), and pasted in this PR (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

#### Acceptance Test Output
<!-- Please paste the results of acceptance tests `make testacc` in the codeblock here. -->
```
$ TF_ACC=1 TF_LOG=INFO go test ./synthetics/... -run TestAccCreateUpdateBrowserCheckV2
ok      github.com/splunk/terraform-provider-synthetics/synthetics      (cached)
```

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

----
