### PR TITLE
Http error handling fix and add retry

### DIFF
--- a/synthetics/resource_browser_check_v2.go
+++ b/synthetics/resource_browser_check_v2.go
@@ -19,6 +19,7 @@ import (
 	"log"
 	"regexp"
 	"strconv"
+	"strings"
 
 	sc2 "github.com/splunk/syntheticsclient/v2/syntheticsclientv2"
 
@@ -359,11 +360,19 @@ func resourceBrowserCheckV2Read(ctx context.Context, d *schema.ResourceData, met
 	}
 
 	o, r, err := c.GetBrowserCheckV2(checkID)
-	if err != nil && (err.Error() == "Status Code: 404 Not Found" || r.StatusCode == 0) {
+
+	if err != nil || r.StatusCode == 404 || r.StatusCode == 0 {
+		log.Println("[WARN] Synthetics API error. Retrying.", checkID, err.Error(), r.StatusCode, r.StatusCode)
+		o, r, err = c.GetBrowserCheckV2(checkID)
+	}
+
+	if err != nil && strings.Contains(err.Error(), "Status Code: 404 Not Found") {
 		d.SetId("")
+		log.Println("[WARN] Synthetics API error.", err.Error(), r.StatusCode, r.StatusCode)
 		log.Println("[WARN] Resource exists in state but not in API. Removing resource from state.")
 		return diags
 	}
+
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/synthetics/resource_http_check_v2.go
+++ b/synthetics/resource_http_check_v2.go
@@ -19,6 +19,7 @@ import (
 	"log"
 	"regexp"
 	"strconv"
+	"strings"
 
 	sc2 "github.com/splunk/syntheticsclient/v2/syntheticsclientv2"
 
@@ -232,11 +233,19 @@ func resourceHttpCheckV2Read(ctx context.Context, d *schema.ResourceData, meta i
 	}
 
 	o, r, err := c.GetHttpCheckV2(checkID)
-	if err != nil && (err.Error() == "Status Code: 404 Not Found" || r.StatusCode == 0) {
+
+	if err != nil || r.StatusCode == 404 || r.StatusCode == 0 {
+		log.Println("[WARN] Synthetics API error. Retrying.", checkID, err.Error(), r.StatusCode, r.StatusCode)
+		o, r, err = c.GetHttpCheckV2(checkID)
+	}
+
+	if err != nil && strings.Contains(err.Error(), "Status Code: 404 Not Found") {
 		d.SetId("")
+		log.Println("[WARN] Synthetics API error.", err.Error(), r.StatusCode, r.StatusCode)
 		log.Println("[WARN] Resource exists in state but not in API. Removing resource from state.")
 		return diags
 	}
+
 	if err != nil {
 		return diag.FromErr(err)
 	}


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are expected for bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
* HTTP error other than 404 will cause terraform to remove the resource state from the state file after this change has been merged
  * https://github.com/splunk/terraform-provider-synthetics/pull/41
* The status code for 404, connection reset, connection timeout are all 0
  * For Example
```
2025-02-17T15:15:47.984Z [WARN]  provider.terraform-provider-synthetics: Synthetics API error. Retrying. Attempt 122510 Get "https://api.eu0.signalfx.com/v2/synthetics/tests/browser/22510": context deadline exceeded (Client.Timeout exceeded while awaiting headers) 0 0: timestamp=2025-02-17T15:15:47.984Z
```
* This means that when the request times out or the connection reset etc, the state will be removed and it will try and create it with the resource already there, ending up with
`Error: Status Code: 422 Unprocessable Entity`
`Response: {"message":"Could not create Browser Test","details":{"name":["has already been taken"]}}`
* The error message of a 404 is also not matching correctly, it's currently using an absolute match with `Status Code: 404 Not Found` but the error message is actually (on two lines)
`Status Code: 404 Not Found`
`Response: {"message":"Record not found"}`
* For Example
```
2025-02-17T14:42:54.186Z [WARN]  provider.terraform-provider-synthetics: Synthetics API error. Retrying. 22455 Status Code: 404 Not Found
Response: {"message":"Record not found"} 0 0: timestamp=2025-02-17T14:42:54.186Z
```

### After the change?
* Only 404 will cause terraform to remove the resource state from the state file which is what the below change is supposed to do
  * https://github.com/splunk/terraform-provider-synthetics/pull/41
* The error message for a 404 should now be matched correctly with strings.contains
* When the request fails it will retry, this is copied over from
  * https://github.com/splunk/terraform-provider-synthetics/commit/afeb44831570509f88a14e28f9f444e1e13a57d7

### Pull request checklist 
- [ ] Acceptance Tests have been updated, run (`make testacc`), and pasted in this PR (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

#### Acceptance Test Output
```
go test ./synthetics/... -run TestAccCreateUpdateBrowserCheckV2 
ok  	github.com/splunk/terraform-provider-synthetics/synthetics	0.011s

go test ./synthetics/... -run TestAccCreateUpdateHttpCheckV2 
ok  	github.com/splunk/terraform-provider-synthetics/synthetics	0.011s
```

### Does this introduce a breaking change?
- [ ] Yes
- [x] No