### PR TITLE
Allow whitespace in custom properties

### DIFF
--- a/synthetics/resource_api_check_v2.go
+++ b/synthetics/resource_api_check_v2.go
@@ -209,7 +209,7 @@ func resourceApiCheckV2() *schema.Resource {
 									"value": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9](\w|-|_){1,128}$`), "custom_properties value can only consist of alphanumeric and underscore characters with no whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9](\w|-|_| ){1,128}$`), "custom_properties value can only consist of alphanumeric and underscore characters and whitespace"),
 									},
 								},
 							},

--- a/synthetics/resource_browser_check_v2.go
+++ b/synthetics/resource_browser_check_v2.go
@@ -312,7 +312,7 @@ func resourceBrowserCheckV2() *schema.Resource {
 									"value": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9](\w|-|_){1,128}$`), "custom_properties value can only consist of alphanumeric and underscore characters with no whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9](\w|-|_| ){1,128}$`), "custom_properties value can only consist of alphanumeric and underscore characters and whitespace"),
 									},
 								},
 							},

--- a/synthetics/resource_browser_check_v2_test.go
+++ b/synthetics/resource_browser_check_v2_test.go
@@ -241,7 +241,7 @@ resource "synthetics_create_browser_check_v2" "browser_v2_foo_check" {
     scheduling_strategy = "concurrent"
     custom_properties {
       key = "beepkey"
-      value = "boopvalue"
+      value = "boop value 2"
     }
     advanced_settings {
       verify_certificates = false
@@ -505,7 +505,7 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.name", "01-acceptance-updated-Terraform-Browser-V2"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.scheduling_strategy", "concurrent"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.custom_properties.0.key", "beepkey"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.custom_properties.0.value", "boopvalue"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.custom_properties.0.value", "boop value 2"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.verify_certificates", "false"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.user_agent", "Jozilla/5.0"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.collect_interactive_metrics", "false"),

--- a/synthetics/resource_http_check_v2.go
+++ b/synthetics/resource_http_check_v2.go
@@ -182,7 +182,7 @@ func resourceHttpCheckV2() *schema.Resource {
 									"value": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9](\w|-|_){1,128}$`), "custom_properties value can only consist of alphanumeric and underscore characters with no whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9](\w|-|_| ){1,128}$`), "custom_properties value can only consist of alphanumeric and underscore characters and whitespace"),
 									},
 								},
 							},

--- a/synthetics/resource_port_check_v2.go
+++ b/synthetics/resource_port_check_v2.go
@@ -114,7 +114,7 @@ func resourcePortCheckV2() *schema.Resource {
 									"value": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9](\w|-|_){1,128}$`), "custom_properties value can only consist of alphanumeric and underscore characters with no whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9](\w|-|_| ){1,128}$`), "custom_properties value can only consist of alphanumeric and underscore characters and whitespace"),
 									},
 								},
 							},


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are expected for bug fixes and features. -->
Resolves #ISSUE_NUMBER

The provider is not allowing to use whitespace in the values for tests custom properties. The API allows it and it's possible to use values with whitespace in the UI, so there's no reason to have stricter validation in TF provider.

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Custom properties values can't contain whitespace

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Custom properties values can contain whitespace

### Pull request checklist 
- [x] Acceptance Tests have been updated, run (`make testacc`), and pasted in this PR (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

#### Acceptance Test Output
<!-- Please paste the results of acceptance tests `make testacc` in the codeblock here. -->
```

```

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [x] No

----
