### PR TITLE
Adding the support to override the defaul the observability api url

### DIFF
--- a/synthetics/provider.go
+++ b/synthetics/provider.go
@@ -17,6 +17,7 @@ package synthetics
 import (
 	"context"
 	"regexp"
+	"strings"
 
 	sc2 "github.com/splunk/syntheticsclient/v2/syntheticsclientv2"
 
@@ -47,6 +48,12 @@ func Provider() *schema.Provider {
 				Required:    true,
 				Description: "Splunk Observability Realm (E.G. `us1`). Will pull from `REALM` environment variable if available. For Rigor use realm rigor",
 				DefaultFunc: schema.EnvDefaultFunc("REALM", nil),
+			},
+			"apiUrl": {
+			    Type:     schema.TypeString,
+			    Optional: true,
+			    Description: "Splunk Observability Realm API Endpoint (E.G. `https://api.<REALM>.signalfx.com`). Will pull from `API_URL` environment variable if available.",
+			    DefaultFunc: schema.EnvDefaultFunc("API_URL", nil),
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
@@ -82,14 +89,26 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	token := d.Get("apikey").(string)
 	realm := d.Get("realm").(string)
 	product := d.Get("product").(string)
+	apiUrl := d.Get("apiUrl").(string)
 
 	var diags diag.Diagnostics
 
 	if product == "observability" {
 		if token != "" && realm != "" {
-			c := sc2.NewClient(token, realm)
-
-			return c, diags
+			if apiUrl != "" {
+				args := sc2.ClientArgs {
+					timeoutSeconds: 30,
+					publicBaseUrl: strings.TrimSuffix(apiUrl, "/") + "/v2/synthetics"
+				}
+				
+				c := sc2.NewConfigurableClient(token, realm, args)
+				
+				return c, diags
+			} else {
+				c := sc2.NewClient(token, realm)
+				
+				return c, diags
+			}
 		}
 
 		c := sc2.NewClient(token, realm)


### PR DESCRIPTION
In one of our example, instead of using `api.<REALM>.signalfx.com` we are making use of `external-api.<REALM>.signalfx.com` api URL. So in order to achieve it, following support is added in which if apiUrl is passed in providers.tf, it wil take precedence otherwise default one will be used

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are expected for bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* 

### Pull request checklist 
- [ ] Acceptance Tests have been updated, run (`make testacc`), and pasted in this PR (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

#### Acceptance Test Output
<!-- Please paste the results of acceptance tests `make testacc` in the codeblock here. -->
```

```

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [ ] No

----
