### PR TITLE
Improving docs

### DIFF
--- a/docs/resources/create_browser_check_v2.md
+++ b/docs/resources/create_browser_check_v2.md
@@ -35,7 +35,7 @@ resource "synthetics_create_browser_check_v2" "long_browser_v2_foo_check" {
       steps {
         name                 = "02 fill in fieldz"
         selector             = "beep"
-        selector_type        = "id"
+        selector_type        = "id" # (Valid types: "id", "name", "xpath", "css", "link", "jspath")
         type                 = "enter_value"
         value                = "{{env.beep-var}}"
       }
@@ -104,6 +104,42 @@ resource "synthetics_create_browser_check_v2" "long_browser_v2_foo_check" {
         type                 = "run_javascript"
         value                = "beeeeeeep"
         wait_for_nav         = true
+      }
+      steps {
+        name                 = "011 Assert element present"
+        type                 = "assert_element_present"
+        selector             = "abcde"
+        selector_type        = "id"
+      }
+      steps {
+        name                 = "012 Assert element not present"
+        type                 = "assert_element_not_present"
+        selector             = "zyxwv"
+        selector_type        = "id"
+      }
+      steps {
+        name                 = "013 Assert element visible"
+        type                 = "assert_element_visible"
+        selector             = "jklmnopq"
+        selector_type        = "id"
+      }
+      steps {
+        name                 = "014 Assert element not visible"
+        type                 = "assert_element_not_visible"
+        selector             = "lkjihgfe"
+        selector_type        = "id"
+      }
+      steps {
+        name                 = "015 Assert text present"
+        type                 = "assert_text_present"
+        selector             = "textabc"
+        selector_type        = "id"
+      }
+      steps {
+        name                 = "016 Assert text not present"
+        type                 = "assert_text_not_present"
+        selector             = "textxyz"
+        selector_type        = "id"
       }
     }
     transactions {


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are expected for bug fixes and features. -->
Resolves #39 

----

### Before the change?
1. Documentation example code does not elaborate upon the valid types for `selector_type` _(which are `id`, `name`, `xpath`, `css`, `link`, `jspath`, as can be determined by trying to pass in `helloworld` as a `selector_type` and getting back an error message clarifying the valid options during `terraform apply`)_.
2. Documentation example code does not mention the existence of any of the 6 "assertion" step types.

* 

### After the change?
1. Left all examples of `selector_type` as `id` as before, but added an inline comment at the end of the first example listing all 6 valid `selector_type` values.
2. Added 6 new "assertion" step `type` examples to cover Documentation example code does not mention the existence of any of the 6 "assertion" step types.

* 

### Pull request checklist 
- [ N/A ] Acceptance Tests have been updated, run (`make testacc`), and pasted in this PR (for bug fixes / features)
- [ X ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

#### Acceptance Test Output
<!-- Please paste the results of acceptance tests `make testacc` in the codeblock here. -->
```
(n/a; .md examples only changed)
```

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [ X ] No

----
