### PR TITLE
SYN-6062: update custom properties validation to be consistent with t…

### DIFF
--- a/synthetics/resource_api_check_v2.go
+++ b/synthetics/resource_api_check_v2.go
@@ -204,12 +204,12 @@ func resourceApiCheckV2() *schema.Resource {
 									"key": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z](\w|-|_){1,128}$`), "custom_properties key must start with a letter and only consist of alphanumeric and underscore characters with no whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z][\w.-]{0,127}$`), "custom_properties key must start with a letter and may contain letters, numbers, underscore, dot, and hyphen, up to 128 characters total with no whitespace"),
 									},
 									"value": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9](\w|-|_| ){1,128}$`), "custom_properties value can only consist of alphanumeric and underscore characters and whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^.{0,256}$`), "custom_properties value must be at most 256 characters"),
 									},
 								},
 							},

--- a/synthetics/resource_browser_check_v2.go
+++ b/synthetics/resource_browser_check_v2.go
@@ -307,12 +307,12 @@ func resourceBrowserCheckV2() *schema.Resource {
 									"key": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z](\w|-|_){1,128}$`), "custom_properties key must start with a letter and only consist of alphanumeric and underscore characters with no whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z][\w.-]{0,127}$`), "custom_properties key must start with a letter and may contain letters, numbers, underscore, dot, and hyphen, up to 128 characters total with no whitespace"),
 									},
 									"value": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9](\w|-|_| ){1,128}$`), "custom_properties value can only consist of alphanumeric and underscore characters and whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^.{0,256}$`), "custom_properties value must be at most 256 characters"),
 									},
 								},
 							},

--- a/synthetics/resource_http_check_v2.go
+++ b/synthetics/resource_http_check_v2.go
@@ -177,12 +177,12 @@ func resourceHttpCheckV2() *schema.Resource {
 									"key": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z](\w|-|_){1,128}$`), "custom_properties key must start with a letter and only consist of alphanumeric and underscore characters with no whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z][\w.-]{0,127}$`), "custom_properties key must start with a letter and may contain letters, numbers, underscore, dot, and hyphen, up to 128 characters total with no whitespace"),
 									},
 									"value": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9](\w|-|_| ){1,128}$`), "custom_properties value can only consist of alphanumeric and underscore characters and whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^.{0,256}$`), "custom_properties value must be at most 256 characters"),
 									},
 								},
 							},

--- a/synthetics/resource_port_check_v2.go
+++ b/synthetics/resource_port_check_v2.go
@@ -109,12 +109,12 @@ func resourcePortCheckV2() *schema.Resource {
 									"key": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z](\w|-|_){1,128}$`), "custom_properties key must start with a letter and only consist of alphanumeric and underscore characters with no whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z][\w.-]{0,127}$`), "custom_properties key must start with a letter and may contain letters, numbers, underscore, dot, and hyphen, up to 128 characters total with no whitespace"),
 									},
 									"value": {
 										Type:         schema.TypeString,
 										Optional:     true,
-										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9](\w|-|_| ){1,128}$`), "custom_properties value can only consist of alphanumeric and underscore characters and whitespace"),
+										ValidateFunc: validation.StringMatch(regexp.MustCompile(`^.{0,256}$`), "custom_properties value must be at most 256 characters"),
 									},
 								},
 							},


### PR DESCRIPTION
…he API

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are expected for bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Custom properties `keys` needed to start with a letter and then contain at most 129(this was a bug) characters including letters, digits, underscores, and hyphens with no whitespace.
* Custom properties `values` needed to start with a letter or digit and then contain at most 129(this was a bug) characters including letters, digits, underscores, hyphens, and whitespace.

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Custom properties `keys` need to start with a letter and then contain at most 128 characters including letters, digits, underscores, hyphens, and dots with no whitespace.
* Custom properties `values` must only contain characters except for newline(`\n`) max length of 256

### Pull request checklist 
- [x] Acceptance Tests have been updated, run (`make testacc`), and pasted in this PR (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

#### Acceptance Test Output
<!-- Please paste the results of acceptance tests `make testacc` in the codeblock here. -->
```

```

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [x] No

----
