### PR TITLE
SYN-6219: add support for v2 synthetics APIs for browser and api tests

### DIFF
--- a/docs/data-sources/browser_v2_check.md
+++ b/docs/data-sources/browser_v2_check.md
@@ -149,19 +149,23 @@ Read-Only:
 Read-Only:
 
 - `action` (String)
+- `duration` (Number)
 - `max_wait_time` (Number)
+- `max_wait_time_default` (Boolean)
 - `name` (String)
 - `option_selector` (String)
 - `option_selector_type` (String)
 - `options` (Set of Object) (see [below for nested schema](#nestedobjatt--test--business_transactions--steps--options))
 - `selector` (String)
 - `selector_type` (String)
+- `selectors` (List of Object) (see [below for nested schema](#nestedobjatt--test--business_transactions--steps--selectors))
 - `type` (String)
 - `url` (String)
 - `value` (String)
 - `variable_name` (String)
 - `wait_for_nav` (Boolean)
 - `wait_for_nav_timeout` (Number)
+- `wait_for_nav_timeout_default` (Boolean)
 
 <a id="nestedobjatt--test--business_transactions--steps--options"></a>
 ### Nested Schema for `test.business_transactions.steps.options`
@@ -169,6 +173,15 @@ Read-Only:
 Read-Only:
 
 - `url` (String)
+
+
+<a id="nestedobjatt--test--business_transactions--steps--selectors"></a>
+### Nested Schema for `test.business_transactions.steps.selectors`
+
+Read-Only:
+
+- `type` (String)
+- `value` (String)
 
 
 
@@ -214,18 +227,21 @@ Read-Only:
 - `action` (String)
 - `duration` (Number)
 - `max_wait_time` (Number)
+- `max_wait_time_default` (Boolean)
 - `name` (String)
 - `option_selector` (String)
 - `option_selector_type` (String)
 - `options` (Set of Object) (see [below for nested schema](#nestedobjatt--test--transactions--steps--options))
 - `selector` (String)
 - `selector_type` (String)
+- `selectors` (List of Object) (see [below for nested schema](#nestedobjatt--test--transactions--steps--selectors))
 - `type` (String)
 - `url` (String)
 - `value` (String)
 - `variable_name` (String)
 - `wait_for_nav` (Boolean)
 - `wait_for_nav_timeout` (Number)
+- `wait_for_nav_timeout_default` (Boolean)
 
 <a id="nestedobjatt--test--transactions--steps--options"></a>
 ### Nested Schema for `test.transactions.steps.options`
@@ -233,3 +249,12 @@ Read-Only:
 Read-Only:
 
 - `url` (String)
+
+
+<a id="nestedobjatt--test--transactions--steps--selectors"></a>
+### Nested Schema for `test.transactions.steps.selectors`
+
+Read-Only:
+
+- `type` (String)
+- `value` (String)

--- a/docs/resources/create_browser_check_v2.md
+++ b/docs/resources/create_browser_check_v2.md
@@ -40,11 +40,17 @@ resource "synthetics_create_browser_check_v2" "long_browser_v2_foo_check" {
         value                = "{{env.beep-var}}"
       }
       steps {
-        name                 = "03 click"
-        selector             = "clicky"
-        selector_type        = "id"
-        type                 = "click_element"
-        wait_for_nav         = true
+        name          = "03 click"
+        type          = "click_element"
+        wait_for_nav  = true
+        selectors {
+          type  = "css"
+          value = ".checkout-primary"
+        }
+        selectors {
+          type  = "id"
+          value = "clicky"
+        }
       }
       steps {
         name                 = "04 accept---Alert"
@@ -283,8 +289,9 @@ Optional:
 - `option_selector` (String)
 - `option_selector_type` (String)
 - `options` (Block Set) (see [below for nested schema](#nestedblock--test--transactions--steps--options))
-- `selector` (String)
-- `selector_type` (String)
+- `selector` (String) Shorthand for the first selector when selectors is not used.
+- `selector_type` (String) Shorthand for the first selector when selectors is not used.
+- `selectors` (Block List) Element locators for this step (1-10). When set, this is sent to the API as the selectors array. selector and selector_type are still supported as a shorthand for a single locator. (see [below for nested schema](#nestedblock--test--transactions--steps--selectors))
 - `type` (String)
 - `url` (String)
 - `value` (String)
@@ -303,6 +310,15 @@ Read-Only:
 Optional:
 
 - `url` (String)
+
+
+<a id="nestedblock--test--transactions--steps--selectors"></a>
+### Nested Schema for `test.transactions.steps.selectors`
+
+Required:
+
+- `type` (String)
+- `value` (String)
 
 
 

--- a/examples/resources/synthetics_create_browser_check_v2/resource.tf
+++ b/examples/resources/synthetics_create_browser_check_v2/resource.tf
@@ -25,11 +25,17 @@ resource "synthetics_create_browser_check_v2" "long_browser_v2_foo_check" {
         value                = "{{env.beep-var}}"
       }
       steps {
-        name                 = "03 click"
-        selector             = "clicky"
-        selector_type        = "id"
-        type                 = "click_element"
-        wait_for_nav         = true
+        name          = "03 click"
+        type          = "click_element"
+        wait_for_nav  = true
+        selectors {
+          type  = "css"
+          value = ".checkout-primary"
+        }
+        selectors {
+          type  = "id"
+          value = "clicky"
+        }
       }
       steps {
         name                 = "04 accept---Alert"

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/splunk/syntheticsclient v1.0.3
-	github.com/splunk/syntheticsclient/v2 v2.0.17
+	github.com/splunk/syntheticsclient/v2 v2.1.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -174,10 +174,8 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/splunk/syntheticsclient v1.0.3 h1:I3PUgTnKZsCNGFH8OgBiQ+sZYYxOwcLmkbi3mp0Qq78=
 github.com/splunk/syntheticsclient v1.0.3/go.mod h1:riH4plM9ySr2lHnWi2E4cocaP9qqlRQHKX6nisiyq6E=
-github.com/splunk/syntheticsclient/v2 v2.0.16 h1:1Nwt33NVnBqHFZ3aCRtkAz1WemNptFsLvyi0t+nqB/M=
-github.com/splunk/syntheticsclient/v2 v2.0.16/go.mod h1:xP4ikfSyA0eVyI72sa11hi9yUDBaQhB5mtW6QSClaWw=
-github.com/splunk/syntheticsclient/v2 v2.0.17 h1:cH8w9bF/6xAoN0sOrsdyN93AUIGV5mw4Eb+nxyq5lLw=
-github.com/splunk/syntheticsclient/v2 v2.0.17/go.mod h1:xP4ikfSyA0eVyI72sa11hi9yUDBaQhB5mtW6QSClaWw=
+github.com/splunk/syntheticsclient/v2 v2.1.0 h1:0b5SwKKEu8qhLIrGT7+0LFK/K0g/qtcu4UElf7WiW5w=
+github.com/splunk/syntheticsclient/v2 v2.1.0/go.mod h1:zW4yCT2gP3MLvUwf95UyBfQJLiSnrRLpufH+VF80Q/A=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/synthetics/data_source_apicheck_v2.go
+++ b/synthetics/data_source_apicheck_v2.go
@@ -312,7 +312,17 @@ func dataSourceApiCheckV2Read(ctx context.Context, d *schema.ResourceData, m int
 		return diag.FromErr(err)
 	}
 
-	checkTest := flattenApiV2Data(check)
+	devices, _, err := c.GetDevicesV2()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	var deviceList []sc2.Device
+	if devices != nil {
+		deviceList = devices.Devices
+	}
+
+	checkTest := flattenApiV2Data(check, deviceList)
 	if err := d.Set("test", checkTest); err != nil {
 		return diag.FromErr(err)
 	}

--- a/synthetics/data_source_browsercheck_v2.go
+++ b/synthetics/data_source_browsercheck_v2.go
@@ -217,72 +217,7 @@ func dataSourceBrowserCheckV2() *schema.Resource {
 										Type:     schema.TypeSet,
 										Computed: true,
 										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"name": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"type": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"url": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"action": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"selector_type": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"selector": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"option_selector_type": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"option_selector": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"variable_name": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"value": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"wait_for_nav": {
-													Type:     schema.TypeBool,
-													Optional: true,
-												},
-												"wait_for_nav_timeout": {
-													Type:     schema.TypeInt,
-													Optional: true,
-												},
-												"max_wait_time": {
-													Type:     schema.TypeInt,
-													Optional: true,
-												},
-												"options": {
-													Type:     schema.TypeSet,
-													Computed: true,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"url": {
-																Type:     schema.TypeString,
-																Optional: true,
-															},
-														},
-													},
-												},
-											},
+											Schema: browserCheckV2StepSchema(true),
 										},
 									},
 								},
@@ -301,76 +236,7 @@ func dataSourceBrowserCheckV2() *schema.Resource {
 										Type:     schema.TypeSet,
 										Computed: true,
 										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"name": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"type": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"url": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"action": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"selector_type": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"selector": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"option_selector_type": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"option_selector": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"variable_name": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"value": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"wait_for_nav": {
-													Type:     schema.TypeBool,
-													Optional: true,
-												},
-												"duration": {
-													Type:     schema.TypeInt,
-													Optional: true,
-												},
-												"wait_for_nav_timeout": {
-													Type:     schema.TypeInt,
-													Optional: true,
-												},
-												"max_wait_time": {
-													Type:     schema.TypeInt,
-													Optional: true,
-												},
-												"options": {
-													Type:     schema.TypeSet,
-													Computed: true,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"url": {
-																Type:     schema.TypeString,
-																Optional: true,
-															},
-														},
-													},
-												},
-											},
+											Schema: browserCheckV2StepSchema(true),
 										},
 									},
 								},
@@ -475,7 +341,17 @@ func dataSourceBrowserCheckV2Read(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
-	checkTest := flattenBrowserV2Data(check)
+	devices, _, err := c.GetDevicesV2()
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	var deviceList []sc2.Device
+	if devices != nil {
+		deviceList = devices.Devices
+	}
+
+	checkTest := flattenBrowserV2Data(check, deviceList)
 	if err := d.Set("test", checkTest); err != nil {
 		return diag.FromErr(err)
 	}

--- a/synthetics/resource_api_check_v2_test.go
+++ b/synthetics/resource_api_check_v2_test.go
@@ -121,7 +121,7 @@ resource "synthetics_create_api_check_v2" "api_v2_foo_check" {
 		active = false
 		device_id = 2  
 		frequency = 15
-		location_ids = ["aws-us-west-1"]
+		location_ids = ["aws-us-west-2"]
 		name = "2 Terraform-Api V2 Acceptance Checkaroo Updated"
 		scheduling_strategy = "concurrent"
 		automatic_retries = 0
@@ -295,7 +295,7 @@ func TestAccCreateUpdateApiCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.device_id", "2"),
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.frequency", "15"),
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.automatic_retries", "0"),
-					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.location_ids.0", "aws-us-west-1"),
+					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.location_ids.0", "aws-us-west-2"),
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.name", "2 Terraform-Api V2 Acceptance Checkaroo Updated"),
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.scheduling_strategy", "concurrent"),
 					resource.TestCheckResourceAttr("synthetics_create_api_check_v2.api_v2_foo_check", "test.0.custom_properties.0.key", "beepkey"),

--- a/synthetics/resource_browser_check_v2.go
+++ b/synthetics/resource_browser_check_v2.go
@@ -212,87 +212,7 @@ func resourceBrowserCheckV2() *schema.Resource {
 										Required:    true,
 										Description: "Unique steps for the transaction. See official [API documentation](https://dev.splunk.com/observability/reference/api/synthetics_browser/latest#endpoint-createbrowsertest) as the source of truth for descriptions and options for these values.",
 										Elem: &schema.Resource{
-											Schema: map[string]*schema.Schema{
-												"name": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"type": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"url": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"action": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"selector_type": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"selector": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"option_selector_type": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"option_selector": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"variable_name": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"value": {
-													Type:     schema.TypeString,
-													Optional: true,
-												},
-												"duration": {
-													Type:     schema.TypeInt,
-													Optional: true,
-												},
-												"wait_for_nav": {
-													Type:     schema.TypeBool,
-													Optional: true,
-													Default:  false,
-												},
-												"wait_for_nav_timeout": {
-													Type:         schema.TypeInt,
-													Optional:     true,
-													ValidateFunc: validation.All(validation.IntAtLeast(1), validation.IntAtMost(20000)),
-												},
-												"wait_for_nav_timeout_default": {
-													Type:     schema.TypeBool,
-													Computed: true,
-												},
-												"max_wait_time": {
-													Type:         schema.TypeInt,
-													Optional:     true,
-													ValidateFunc: validation.All(validation.IntAtLeast(1), validation.IntAtMost(90000)),
-												},
-												"max_wait_time_default": {
-													Type:     schema.TypeBool,
-													Computed: true,
-												},
-												"options": {
-													Type:     schema.TypeSet,
-													Optional: true,
-													Elem: &schema.Resource{
-														Schema: map[string]*schema.Schema{
-															"url": {
-																Type:     schema.TypeString,
-																Optional: true,
-															},
-														},
-													},
-												},
-											},
+											Schema: browserCheckV2StepSchema(false),
 										},
 									},
 								},
@@ -336,7 +256,10 @@ func resourceBrowserCheckV2Create(ctx context.Context, d *schema.ResourceData, m
 	c := meta.(*sc2.Client)
 	// Warning or errors can be collected in a slice type
 	var diags diag.Diagnostics
-	checkData := processBrowserCheckV2Items(d)
+	checkData, err := processBrowserCheckV2Items(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	o, _, err := c.CreateBrowserCheckV2(&checkData)
 	if err != nil {
 		return diag.FromErr(err)
@@ -409,7 +332,10 @@ func resourceBrowserCheckV2Update(ctx context.Context, d *schema.ResourceData, m
 
 	log.Println("[DEBUG] UPDATE BROWSER CHECK ID: ", checkID)
 
-	checkData := processBrowserCheckV2Items(d)
+	checkData, err := processBrowserCheckV2Items(d)
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	checkIdString, err := strconv.Atoi(checkID)
 	if err != nil {
@@ -425,9 +351,168 @@ func resourceBrowserCheckV2Update(ctx context.Context, d *schema.ResourceData, m
 	return resourceBrowserCheckV2Read(ctx, d, meta)
 }
 
-func processBrowserCheckV2Items(d *schema.ResourceData) sc2.BrowserCheckV2Input {
-
-	var check = buildBrowserV2Data(d)
+func processBrowserCheckV2Items(d *schema.ResourceData) (sc2.BrowserCheckV2Input, error) {
+	check, err := buildBrowserV2Data(d)
+	if err != nil {
+		return check, err
+	}
 	log.Println("[DEBUG] BROWSER V2 CHECK OUTPUT: ", check)
-	return check
+	return check, nil
+}
+
+var browserCheckV2SelectorTypes = []string{
+	"id",
+	"name",
+	"xpath",
+	"css",
+	"link",
+	"jspath",
+}
+
+func browserCheckV2SelectorSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"type": {
+			Type:         schema.TypeString,
+			Required:     true,
+			ValidateFunc: validation.StringInSlice(browserCheckV2SelectorTypes, false),
+		},
+		"value": {
+			Type:     schema.TypeString,
+			Required: true,
+		},
+	}
+}
+
+// browserCheckV2StepSchema returns the schema for a browser test transaction step.
+// When computed is true, fields are marked computed (for data sources).
+func browserCheckV2StepSchema(computed bool) map[string]*schema.Schema {
+	optional := !computed
+
+	selectorsSchema := &schema.Schema{
+		Type:     schema.TypeList,
+		Elem:     &schema.Resource{Schema: browserCheckV2SelectorSchema()},
+		Optional: optional,
+		Computed: computed,
+		Description: "Element locators for this step (1-10). When set, this is sent to the API as the selectors array. " +
+			"selector and selector_type are still supported as a shorthand for a single locator.",
+	}
+
+	selectorTypeSchema := &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    optional,
+		Computed:    computed,
+		Description: "Shorthand for the first selector when selectors is not used.",
+	}
+	selectorSchema := &schema.Schema{
+		Type:        schema.TypeString,
+		Optional:    optional,
+		Computed:    computed,
+		Description: "Shorthand for the first selector when selectors is not used.",
+	}
+
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Optional: optional,
+			Computed: computed,
+		},
+		"type": {
+			Type:     schema.TypeString,
+			Optional: optional,
+			Computed: computed,
+		},
+		"url": {
+			Type:     schema.TypeString,
+			Optional: optional,
+			Computed: computed,
+		},
+		"action": {
+			Type:     schema.TypeString,
+			Optional: optional,
+			Computed: computed,
+		},
+		"selectors":        selectorsSchema,
+		"selector_type":    selectorTypeSchema,
+		"selector":         selectorSchema,
+		"option_selector_type": {
+			Type:     schema.TypeString,
+			Optional: optional,
+			Computed: computed,
+		},
+		"option_selector": {
+			Type:     schema.TypeString,
+			Optional: optional,
+			Computed: computed,
+		},
+		"variable_name": {
+			Type:     schema.TypeString,
+			Optional: optional,
+			Computed: computed,
+		},
+		"value": {
+			Type:     schema.TypeString,
+			Optional: optional,
+			Computed: computed,
+		},
+		"duration": {
+			Type:     schema.TypeInt,
+			Optional: optional,
+			Computed: computed,
+		},
+		"wait_for_nav": func() *schema.Schema {
+			s := &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: optional,
+				Computed: computed,
+			}
+			if !computed {
+				s.Default = false
+			}
+			return s
+		}(),
+		"wait_for_nav_timeout": func() *schema.Schema {
+			s := &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: optional,
+				Computed: computed,
+			}
+			if !computed {
+				s.ValidateFunc = validation.All(validation.IntAtLeast(1), validation.IntAtMost(20000))
+			}
+			return s
+		}(),
+		"wait_for_nav_timeout_default": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+		"max_wait_time": func() *schema.Schema {
+			s := &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: optional,
+				Computed: computed,
+			}
+			if !computed {
+				s.ValidateFunc = validation.All(validation.IntAtLeast(1), validation.IntAtMost(90000))
+			}
+			return s
+		}(),
+		"max_wait_time_default": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+		"options": {
+			Type:     schema.TypeSet,
+			Optional: optional,
+			Computed: computed,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"url": {
+						Type:     schema.TypeString,
+						Optional: optional,
+						Computed: computed,
+					},
+				},
+			},
+		},
+	}
 }

--- a/synthetics/resource_browser_check_v2.go
+++ b/synthetics/resource_browser_check_v2.go
@@ -409,6 +409,12 @@ func browserCheckV2StepSchema(computed bool) map[string]*schema.Schema {
 		Computed:    computed,
 		Description: "Shorthand for the first selector when selectors is not used.",
 	}
+	if !computed {
+		suppress := browserCheckV2SelectorRepresentationDiffSuppress
+		selectorsSchema.DiffSuppressFunc = suppress
+		selectorTypeSchema.DiffSuppressFunc = suppress
+		selectorSchema.DiffSuppressFunc = suppress
+	}
 
 	return map[string]*schema.Schema{
 		"name": {

--- a/synthetics/resource_browser_check_v2_diff.go
+++ b/synthetics/resource_browser_check_v2_diff.go
@@ -1,0 +1,85 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package synthetics
+
+import (
+	"regexp"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+var browserCheckV2StepAttrPrefixRe = regexp.MustCompile(`^(test\.\d+\.transactions\.\d+\.steps\.\d+)\.`)
+
+// browserCheckV2SelectorRepresentationDiffSuppress suppresses cosmetic plan diffs when
+// state and config describe the same single selector via different field shapes. It does
+// not suppress the one-time migration from legacy fields in state to a selectors block
+// in config.
+func browserCheckV2SelectorRepresentationDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	prefix := browserCheckV2StepPrefixFromAttributeKey(k)
+	if prefix == "" {
+		return false
+	}
+	oldIn := stepSelectorInputFromResourceData(d, prefix, true)
+	newIn := stepSelectorInputFromResourceData(d, prefix, false)
+	if !stepSelectorInputsEquivalent(oldIn, newIn) {
+		return false
+	}
+	if migratingFromLegacyToSelectors(oldIn, newIn) {
+		return false
+	}
+	return stepSelectorRepresentationDiffers(oldIn, newIn)
+}
+
+func browserCheckV2StepPrefixFromAttributeKey(key string) string {
+	m := browserCheckV2StepAttrPrefixRe.FindStringSubmatch(key)
+	if len(m) < 2 {
+		return ""
+	}
+	return m[1]
+}
+
+func stepSelectorInputFromResourceData(d *schema.ResourceData, prefix string, useState bool) stepSelectorInput {
+	var in stepSelectorInput
+	in.selectorType = stringFromResourceDataField(d, prefix+".selector_type", useState)
+	in.selector = stringFromResourceDataField(d, prefix+".selector", useState)
+	if raw := interfaceFromResourceDataField(d, prefix+".selectors", useState); raw != nil {
+		in.selectors = parseSelectorsList(raw)
+	}
+	return in
+}
+
+func stringFromResourceDataField(d *schema.ResourceData, key string, useState bool) string {
+	v := interfaceFromResourceDataField(d, key, useState)
+	if v == nil {
+		return ""
+	}
+	s, _ := v.(string)
+	return s
+}
+
+func interfaceFromResourceDataField(d *schema.ResourceData, key string, useState bool) interface{} {
+	if d.HasChange(key) {
+		o, n := d.GetChange(key)
+		if useState {
+			return o
+		}
+		return n
+	}
+	v, ok := d.GetOk(key)
+	if !ok {
+		return nil
+	}
+	return v
+}

--- a/synthetics/resource_browser_check_v2_test.go
+++ b/synthetics/resource_browser_check_v2_test.go
@@ -316,8 +316,10 @@ resource "synthetics_create_browser_check_v2" "browser_v2_foo_check" {
         name                 = "06 Select-Val-Val"
         option_selector      = "{{env.acceptance-variable-terraform-test}}"
         option_selector_type = "value"
-        selector             = "valz"
-        selector_type        = "id"
+        selectors {
+          type  = "id"
+          value = "valz"
+        }
         type                 = "select_option"
         wait_for_nav         = false
       }
@@ -325,8 +327,10 @@ resource "synthetics_create_browser_check_v2" "browser_v2_foo_check" {
         name                 = "07 Select-Val-Index"
         option_selector      = "{{env.acceptance-variable-terraform-test}}"
         option_selector_type = "index"
-        selector             = "selectionz"
-        selector_type        = "id"
+        selectors {
+          type  = "id"
+          value = "selectionz"
+        }
         type                 = "select_option"
         wait_for_nav         = false
       }
@@ -456,8 +460,7 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.0.wait_for_nav_timeout", "0"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.0.max_wait_time", "0"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.1.name", "02 fill in fieldz"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.1.selector", "beep"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.1.selector_type", "id"),
+					testAccCheckBrowserV2SingleSelector("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.1", "id", "beep"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.1.type", "enter_value"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.1.value", "{{env.acceptance-variable-terraform-test}}"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.1.wait_for_nav", "false"),
@@ -498,8 +501,7 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.0.wait_for_nav_timeout", "0"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.0.max_wait_time", "0"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.1.name", "fill in more fields field"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.1.selector", "beep"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.1.selector_type", "id"),
+					testAccCheckBrowserV2SingleSelector("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.1", "id", "beep"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.1.type", "enter_value"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.1.value", "{{env.acceptance-variable-terraform-test}}"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.1.wait_for_nav", "false"),
@@ -508,15 +510,13 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.1.max_wait_time", "0"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.2.name", "assert element visible"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.2.type", "assert_element_visible"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.2.selector", "beep"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.2.selector_type", "id"),
+					testAccCheckBrowserV2SingleSelector("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.2", "id", "beep"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.2.wait_for_nav", "false"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.2.wait_for_nav_timeout", "0"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.2.max_wait_time", "1000"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.3.name", "assert element visible no max wait time"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.3.type", "assert_element_visible"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.3.selector", "beep"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.3.selector_type", "id"),
+					testAccCheckBrowserV2SingleSelector("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.3", "id", "beep"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.3.wait_for_nav", "false"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.3.wait_for_nav_timeout", "0"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.3.max_wait_time", "0"),
@@ -575,8 +575,7 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.1.name", "06 Select-Val-Val"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.1.option_selector", "{{env.acceptance-variable-terraform-test}}"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.1.option_selector_type", "value"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.1.selector", "valz"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.1.selector_type", "id"),
+					testAccCheckBrowserV2SingleSelector("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.1", "id", "valz"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.1.type", "select_option"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.1.wait_for_nav", "false"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.1.wait_for_nav_timeout", "0"),
@@ -584,8 +583,7 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.name", "07 Select-Val-Index"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.option_selector", "{{env.acceptance-variable-terraform-test}}"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.option_selector_type", "index"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.selector", "selectionz"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.selector_type", "id"),
+					testAccCheckBrowserV2SingleSelector("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2", "id", "selectionz"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.type", "select_option"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.wait_for_nav", "false"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.wait_for_nav_timeout", "0"),
@@ -625,8 +623,7 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.0.type", "go_to_url"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.0.url", "https://www.splunk.com"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.1.name", "fill in more fields field"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.1.selector", "beep"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.1.selector_type", "id"),
+					testAccCheckBrowserV2SingleSelector("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.1", "id", "beep"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.1.type", "enter_value"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.1.value", "{{env.acceptance-variable-terraform-test}}"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.1.wait_for_nav", "false"),
@@ -634,8 +631,7 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.1.max_wait_time", "0"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.2.name", "assert element visible"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.2.type", "assert_element_visible"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.2.selector", "beep"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.2.selector_type", "id"),
+					testAccCheckBrowserV2SingleSelector("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.2", "id", "beep"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.2.wait_for_nav", "false"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.2.wait_for_nav_timeout", "0"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.2.max_wait_time", "0"),
@@ -653,4 +649,12 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckBrowserV2SingleSelector(resourceName, stepPath, selectorType, selectorValue string) resource.TestCheckFunc {
+	return resource.ComposeTestCheckFunc(
+		resource.TestCheckResourceAttr(resourceName, stepPath+".selectors.#", "1"),
+		resource.TestCheckResourceAttr(resourceName, stepPath+".selectors.0.type", selectorType),
+		resource.TestCheckResourceAttr(resourceName, stepPath+".selectors.0.value", selectorValue),
+	)
 }

--- a/synthetics/resource_browser_check_v2_test.go
+++ b/synthetics/resource_browser_check_v2_test.go
@@ -106,11 +106,17 @@ resource "synthetics_create_browser_check_v2" "browser_v2_foo_check" {
         wait_for_nav_timeout = null
       }
       steps {
-        name                 = "03 click"
-        selector             = "clicky"
-        selector_type        = "id"
-        type                 = "click_element"
-        wait_for_nav         = true
+        name         = "03 click"
+        type         = "click_element"
+        wait_for_nav = true
+        selectors {
+          type  = "css"
+          value = ".checkout-primary"
+        }
+        selectors {
+          type  = "id"
+          value = "clicky"
+        }
       }
       steps {
         name                 = "04 accept---Alert"
@@ -120,11 +126,17 @@ resource "synthetics_create_browser_check_v2" "browser_v2_foo_check" {
         name                 = "05 Select-val-text"
         option_selector      = "sdad"
         option_selector_type = "text"
-        selector             = "textzz"
-        selector_type        = "id"
         type                 = "select_option"
         wait_for_nav         = false
         wait_for_nav_timeout = 1
+        selectors {
+          type  = "css"
+          value = ".select-target"
+        }
+        selectors {
+          type  = "id"
+          value = "textzz"
+        }
       }
     }
     transactions {
@@ -163,11 +175,17 @@ resource "synthetics_create_browser_check_v2" "browser_v2_foo_check" {
         url                  = "https://www.splunk.com"
       }
       steps {
-        name                 = "wait_for_nav true -> false with default timeout"
-        selector             = "#buy"
-        selector_type        = "id"
-        type                 = "click_element"
-        wait_for_nav         = true
+        name         = "wait_for_nav true -> false with default timeout"
+        type         = "click_element"
+        wait_for_nav = true
+        selectors {
+          type  = "id"
+          value = "#buy"
+        }
+        selectors {
+          type  = "xpath"
+          value = "//button[@id='buy']"
+        }
       }
       steps {
         name                 = "wait_for_nav false -> true with default timeout"
@@ -235,7 +253,7 @@ resource "synthetics_create_browser_check_v2" "browser_v2_foo_check" {
     active = false
     device_id = 2
     frequency = 15
-    location_ids = ["aws-us-west-1"]
+    location_ids = ["aws-us-west-2"]
     automatic_retries = 0
     name = "01-acceptance-updated-Terraform-Browser-V2"
     scheduling_strategy = "concurrent"
@@ -313,11 +331,17 @@ resource "synthetics_create_browser_check_v2" "browser_v2_foo_check" {
         wait_for_nav         = false
       }
       steps {
-        name                 = "08 Save as text"
-        selector             = "beepval"
-        selector_type        = "link"
-        type                 = "store_variable_from_element"
-        variable_name        = "{{env.terraform-test-foo-301}}"
+        name          = "08 Save as text"
+        type          = "store_variable_from_element"
+        variable_name = "{{env.terraform-test-foo-301}}"
+        selectors {
+          type  = "xpath"
+          value = "//a[contains(@class,'beep')]"
+        }
+        selectors {
+          type  = "link"
+          value = "beepval"
+        }
       }
       steps {
         name                 = "08.5 Wait"
@@ -361,11 +385,17 @@ resource "synthetics_create_browser_check_v2" "browser_v2_foo_check" {
         selector_type        = "id"
       }
       steps {
-        name                 = "assert element visible with max wait time"
-        type                 = "assert_element_visible"
-        selector             = "beep"
-        selector_type        = "id"
-        max_wait_time        = "20000"
+        name          = "assert element visible with max wait time"
+        type          = "assert_element_visible"
+        max_wait_time = "20000"
+        selectors {
+          type  = "css"
+          value = ".beep-visible"
+        }
+        selectors {
+          type  = "id"
+          value = "beep"
+        }
       }
     }
   }
@@ -435,8 +465,11 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.1.wait_for_nav_timeout_default", "true"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.1.max_wait_time", "0"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.name", "03 click"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.selector", "clicky"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.selector_type", "id"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.selectors.#", "2"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.selectors.0.type", "css"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.selectors.0.value", ".checkout-primary"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.selectors.1.type", "id"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.selectors.1.value", "clicky"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.type", "click_element"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.wait_for_nav", "true"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.wait_for_nav_timeout", "0"),
@@ -449,8 +482,11 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.4.name", "05 Select-val-text"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.4.option_selector", "sdad"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.4.option_selector_type", "text"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.4.selector", "textzz"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.4.selector_type", "id"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.4.selectors.#", "2"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.4.selectors.0.type", "css"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.4.selectors.0.value", ".select-target"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.4.selectors.1.type", "id"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.4.selectors.1.value", "textzz"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.4.type", "select_option"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.4.wait_for_nav", "false"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.4.wait_for_nav_timeout", "1"),
@@ -501,7 +537,7 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.device_id", "2"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.frequency", "15"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.automatic_retries", "0"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.location_ids.0", "aws-us-west-1"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.location_ids.0", "aws-us-west-2"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.name", "01-acceptance-updated-Terraform-Browser-V2"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.scheduling_strategy", "concurrent"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.custom_properties.0.key", "beepkey"),
@@ -555,8 +591,11 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.wait_for_nav_timeout", "0"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.2.max_wait_time", "0"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.3.name", "08 Save as text"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.3.selector", "beepval"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.3.selector_type", "link"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.3.selectors.#", "2"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.3.selectors.0.type", "xpath"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.3.selectors.0.value", "//a[contains(@class,'beep')]"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.3.selectors.1.type", "link"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.3.selectors.1.value", "beepval"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.3.type", "store_variable_from_element"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.3.variable_name", "{{env.terraform-test-foo-301}}"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.0.steps.3.wait_for_nav", "false"),
@@ -602,8 +641,11 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.2.max_wait_time", "0"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.3.name", "assert element visible with max wait time"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.3.type", "assert_element_visible"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.3.selector", "beep"),
-					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.3.selector_type", "id"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.3.selectors.#", "2"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.3.selectors.0.type", "css"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.3.selectors.0.value", ".beep-visible"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.3.selectors.1.type", "id"),
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.3.selectors.1.value", "beep"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.3.wait_for_nav", "false"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.3.wait_for_nav_timeout", "0"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.transactions.1.steps.3.max_wait_time", "20000"),

--- a/synthetics/resource_http_check_v2_test.go
+++ b/synthetics/resource_http_check_v2_test.go
@@ -26,7 +26,7 @@ resource "synthetics_create_http_check_v2" "http_v2_foo_check" {
   test {
     active = true 
     frequency = 5
-    location_ids = ["aws-us-east-1","aws-us-west-1"]
+    location_ids = ["aws-us-east-1","aws-us-west-2"]
     name = "01-acceptance-Terraform-HTTP-V2"
     type = "http"
     url = "https://www.splunk.com"
@@ -72,7 +72,7 @@ resource "synthetics_create_http_check_v2" "http_v2_foo_check" {
   test {
     active = false 
     frequency = 15
-    location_ids = ["aws-us-west-1"]
+    location_ids = ["aws-us-west-2"]
     name = "01-acceptance-updated-Terraform-HTTP-V2"
     type = "http"
     url = "https://www.duckduckgo.com"
@@ -127,7 +127,7 @@ func TestAccCreateUpdateHttpCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.frequency", "5"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.automatic_retries", "1"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.location_ids.0", "aws-us-east-1"),
-					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.location_ids.1", "aws-us-west-1"),
+					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.location_ids.1", "aws-us-west-2"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.name", "01-acceptance-Terraform-HTTP-V2"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.type", "http"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.url", "https://www.splunk.com"),
@@ -168,7 +168,7 @@ func TestAccCreateUpdateHttpCheckV2(t *testing.T) {
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.active", "false"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.frequency", "15"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.automatic_retries", "0"),
-					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.location_ids.0", "aws-us-west-1"),
+					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.location_ids.0", "aws-us-west-2"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.name", "01-acceptance-updated-Terraform-HTTP-V2"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.type", "http"),
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.url", "https://www.duckduckgo.com"),

--- a/synthetics/structures.go
+++ b/synthetics/structures.go
@@ -99,13 +99,6 @@ func flattenDeviceFromID(deviceID int, devices []sc2.Device) []interface{} {
 	return []interface{}{}
 }
 
-func selectorFieldsFromSelectors(selectors []sc2.Selector) (selectorType, selector string) {
-	if len(selectors) == 0 {
-		return "", ""
-	}
-	return selectors[0].Type, selectors[0].Value
-}
-
 const browserCheckV2MaxSelectors = 10
 
 func selectorsFromFields(selectorType, selector string) []sc2.Selector {
@@ -113,6 +106,76 @@ func selectorsFromFields(selectorType, selector string) []sc2.Selector {
 		return nil
 	}
 	return []sc2.Selector{{Type: selectorType, Value: selector}}
+}
+
+// stepSelectorInput holds legacy and selectors-block fields for one browser step.
+type stepSelectorInput struct {
+	selectorType string
+	selector     string
+	selectors    []sc2.Selector
+}
+
+func parseSelectorsList(raw interface{}) []sc2.Selector {
+	list, ok := raw.([]interface{})
+	if !ok || len(list) == 0 {
+		return nil
+	}
+	out := make([]sc2.Selector, 0, len(list))
+	for _, item := range list {
+		m, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		selType := stepStringField(m, "type")
+		selValue := stepStringField(m, "value")
+		if selType == "" || selValue == "" {
+			continue
+		}
+		out = append(out, sc2.Selector{Type: selType, Value: selValue})
+	}
+	return out
+}
+
+// resolveSingleSelector returns the single selector implied by the step, using the
+// same precedence as buildSelectorsFromStep. ok is false when there are multiple
+// selectors or no selector at all.
+func (in stepSelectorInput) resolveSingleSelector() (selectorType, selector string, ok bool) {
+	if len(in.selectors) > 1 {
+		return "", "", false
+	}
+	if len(in.selectors) == 1 {
+		return in.selectors[0].Type, in.selectors[0].Value, true
+	}
+	if in.selectorType != "" && in.selector != "" {
+		return in.selectorType, in.selector, true
+	}
+	return "", "", false
+}
+
+func stepSelectorInputsEquivalent(a, b stepSelectorInput) bool {
+	aType, aVal, aOK := a.resolveSingleSelector()
+	bType, bVal, bOK := b.resolveSingleSelector()
+	return aOK && bOK && aType == bType && aVal == bVal
+}
+
+// stepSelectorRepresentationDiffers is true when state and config encode the same
+// single selector using different Terraform fields (legacy vs selectors block).
+func stepSelectorRepresentationDiffers(a, b stepSelectorInput) bool {
+	aUsesList := len(a.selectors) > 0
+	bUsesList := len(b.selectors) > 0
+	aUsesLegacy := a.selector != "" || a.selectorType != ""
+	bUsesLegacy := b.selector != "" || b.selectorType != ""
+	return aUsesList != bUsesList || aUsesLegacy != bUsesLegacy
+}
+
+// migratingFromLegacyToSelectors is true when state still has legacy fields and
+// config has moved to a single selectors block (the one-time migration shape).
+func migratingFromLegacyToSelectors(state, config stepSelectorInput) bool {
+	stateUsesLegacy := state.selector != "" || state.selectorType != ""
+	stateUsesList := len(state.selectors) > 0
+	configUsesList := len(config.selectors) == 1
+	configUsesLegacy := config.selector != "" || config.selectorType != ""
+	return stateUsesLegacy && !stateUsesList && configUsesList && !configUsesLegacy
 }
 
 func flattenSelectorsData(selectors []sc2.Selector) []interface{} {
@@ -1128,23 +1191,12 @@ func flattenStepsData(checkSteps *[]sc2.StepsV2) []interface{} {
 
 			cl["max_wait_time_default"] = checkStep.MaxWaitTimeDefault
 
-			// Only expose selectors blocks when there are multiple; a single selector
-			// is represented via legacy selector/selector_type to avoid plan drift when
-			// config uses those fields only.
-			if len(checkStep.Selectors) > 1 {
+			// Persist all API selectors (including a single one) as selectors blocks so
+			// config using selectors { } stays in sync after apply. Legacy fields are only
+			// written when the API returns no selectors.
+			if len(checkStep.Selectors) > 0 {
 				if selectors := flattenSelectorsData(checkStep.Selectors); selectors != nil {
 					cl["selectors"] = selectors
-				}
-			}
-
-			// Legacy fields only for a single selector; multi-selector steps use selectors blocks only.
-			if len(checkStep.Selectors) <= 1 {
-				selectorType, selector := selectorFieldsFromSelectors(checkStep.Selectors)
-				if selector != "" {
-					cl["selector"] = selector
-				}
-				if selectorType != "" {
-					cl["selector_type"] = selectorType
 				}
 			}
 
@@ -1752,10 +1804,29 @@ func buildCustomPropertiesData(customProperties *schema.Set) []sc2.CustomPropert
 	return customPropertiesList
 }
 
+// dropStaleStepSelectors removes a single selectors block carried over from state
+// when legacy selector fields were updated to different values in config.
+func dropStaleStepSelectors(step map[string]interface{}) {
+	legacyType := stepStringField(step, "selector_type")
+	legacyVal := stepStringField(step, "selector")
+	if legacyType == "" || legacyVal == "" {
+		return
+	}
+	stale := parseSelectorsList(step["selectors"])
+	if len(stale) != 1 {
+		return
+	}
+	if stale[0].Type == legacyType && stale[0].Value == legacyVal {
+		return
+	}
+	delete(step, "selectors")
+}
+
 func buildStepV2Data(steps []interface{}) ([]sc2.StepsV2, error) {
 	stepsList := make([]sc2.StepsV2, len(steps))
 	for i, step := range steps {
 		step := step.(map[string]interface{})
+		dropStaleStepSelectors(step)
 		selectors, err := buildSelectorsFromStep(step)
 		if err != nil {
 			return nil, err

--- a/synthetics/structures.go
+++ b/synthetics/structures.go
@@ -15,6 +15,7 @@
 package synthetics
 
 import (
+	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -63,7 +64,7 @@ func flattenApiV2Read(checkApiV2 *sc2.ApiCheckV2Response) []interface{} {
 		apiV2["scheduling_strategy"] = checkApiV2.Test.Schedulingstrategy
 	}
 
-	apiV2["device_id"] = checkApiV2.Test.Device.ID
+	apiV2["device_id"] = checkApiV2.Test.Deviceid
 
 	locationIds := flattenLocationData(&checkApiV2.Test.Locationids)
 	apiV2["location_ids"] = locationIds
@@ -79,7 +80,97 @@ func flattenApiV2Read(checkApiV2 *sc2.ApiCheckV2Response) []interface{} {
 	return []interface{}{apiV2}
 }
 
-func flattenApiV2Data(checkApiV2 *sc2.ApiCheckV2Response) []interface{} {
+func findDeviceByID(devices []sc2.Device, deviceID int) *sc2.Device {
+	for i := range devices {
+		if devices[i].ID == deviceID {
+			return &devices[i]
+		}
+	}
+	return nil
+}
+
+func flattenDeviceFromID(deviceID int, devices []sc2.Device) []interface{} {
+	if device := findDeviceByID(devices, deviceID); device != nil {
+		return flattenDeviceData(device)
+	}
+	if deviceID != 0 {
+		return flattenDeviceData(&sc2.Device{ID: deviceID})
+	}
+	return []interface{}{}
+}
+
+func selectorFieldsFromSelectors(selectors []sc2.Selector) (selectorType, selector string) {
+	if len(selectors) == 0 {
+		return "", ""
+	}
+	return selectors[0].Type, selectors[0].Value
+}
+
+const browserCheckV2MaxSelectors = 10
+
+func selectorsFromFields(selectorType, selector string) []sc2.Selector {
+	if selectorType == "" || selector == "" {
+		return nil
+	}
+	return []sc2.Selector{{Type: selectorType, Value: selector}}
+}
+
+func flattenSelectorsData(selectors []sc2.Selector) []interface{} {
+	if len(selectors) == 0 {
+		return nil
+	}
+	cls := make([]interface{}, len(selectors))
+	for i, sel := range selectors {
+		cls[i] = map[string]interface{}{
+			"type":  sel.Type,
+			"value": sel.Value,
+		}
+	}
+	return cls
+}
+
+func stepStringField(step map[string]interface{}, key string) string {
+	if v, ok := step[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+func buildSelectorsFromStep(step map[string]interface{}) ([]sc2.Selector, error) {
+	if raw, ok := step["selectors"]; ok && raw != nil {
+		list, ok := raw.([]interface{})
+		if ok && len(list) > 0 {
+			if len(list) > browserCheckV2MaxSelectors {
+				return nil, fmt.Errorf(
+					"step %q has %d selectors; maximum is %d",
+					stepStringField(step, "name"),
+					len(list),
+					browserCheckV2MaxSelectors,
+				)
+			}
+			result := make([]sc2.Selector, len(list))
+			for i, item := range list {
+				m, ok := item.(map[string]interface{})
+				if !ok {
+					return nil, fmt.Errorf("step %q: invalid selector at index %d", stepStringField(step, "name"), i)
+				}
+				selType := stepStringField(m, "type")
+				selValue := stepStringField(m, "value")
+				if selType == "" || selValue == "" {
+					return nil, fmt.Errorf("step %q: selector at index %d requires type and value", stepStringField(step, "name"), i)
+				}
+				result[i] = sc2.Selector{Type: selType, Value: selValue}
+			}
+			return result, nil
+		}
+	}
+	return selectorsFromFields(
+		stepStringField(step, "selector_type"),
+		stepStringField(step, "selector"),
+	), nil
+}
+
+func flattenApiV2Data(checkApiV2 *sc2.ApiCheckV2Response, devices []sc2.Device) []interface{} {
 	apiV2 := make(map[string]interface{})
 
 	apiV2["active"] = checkApiV2.Test.Active
@@ -132,8 +223,7 @@ func flattenApiV2Data(checkApiV2 *sc2.ApiCheckV2Response) []interface{} {
 		apiV2["type"] = checkApiV2.Test.Type
 	}
 
-	device := flattenDeviceData(&checkApiV2.Test.Device)
-	apiV2["device"] = device
+	apiV2["device"] = flattenDeviceFromID(checkApiV2.Test.Deviceid, devices)
 
 	locationIds := flattenLocationData(&checkApiV2.Test.Locationids)
 	apiV2["location_ids"] = locationIds
@@ -507,7 +597,7 @@ func flattenBrowserV2Read(checkBrowserV2 *sc2.BrowserCheckV2Response) []interfac
 	browserV2["active"] = checkBrowserV2.Test.Active
 	browserV2["automatic_retries"] = checkBrowserV2.Test.Automaticretries
 
-	browserV2["device_id"] = checkBrowserV2.Test.Device.ID
+	browserV2["device_id"] = checkBrowserV2.Test.Deviceid
 
 	if checkBrowserV2.Test.Frequency != 0 {
 		browserV2["frequency"] = checkBrowserV2.Test.Frequency
@@ -538,7 +628,7 @@ func flattenBrowserV2Read(checkBrowserV2 *sc2.BrowserCheckV2Response) []interfac
 	return []interface{}{browserV2}
 }
 
-func flattenBrowserV2Data(checkBrowserV2 *sc2.BrowserCheckV2Response) []interface{} {
+func flattenBrowserV2Data(checkBrowserV2 *sc2.BrowserCheckV2Response, devices []sc2.Device) []interface{} {
 	browserV2 := make(map[string]interface{})
 
 	browserV2["active"] = checkBrowserV2.Test.Active
@@ -594,8 +684,7 @@ func flattenBrowserV2Data(checkBrowserV2 *sc2.BrowserCheckV2Response) []interfac
 	locationIds := flattenLocationData(&checkBrowserV2.Test.Locationids)
 	browserV2["location_ids"] = locationIds
 
-	device := flattenDeviceData(&checkBrowserV2.Test.Device)
-	browserV2["device"] = device
+	browserV2["device"] = flattenDeviceFromID(checkBrowserV2.Test.Deviceid, devices)
 
 	advancedSettings := flattenAdvancedSettingsData(&checkBrowserV2.Test.Advancedsettings)
 	browserV2["advanced_settings"] = advancedSettings
@@ -1039,12 +1128,24 @@ func flattenStepsData(checkSteps *[]sc2.StepsV2) []interface{} {
 
 			cl["max_wait_time_default"] = checkStep.MaxWaitTimeDefault
 
-			if checkStep.Selector != "" {
-				cl["selector"] = checkStep.Selector
+			// Only expose selectors blocks when there are multiple; a single selector
+			// is represented via legacy selector/selector_type to avoid plan drift when
+			// config uses those fields only.
+			if len(checkStep.Selectors) > 1 {
+				if selectors := flattenSelectorsData(checkStep.Selectors); selectors != nil {
+					cl["selectors"] = selectors
+				}
 			}
 
-			if checkStep.SelectorType != "" {
-				cl["selector_type"] = checkStep.SelectorType
+			// Legacy fields only for a single selector; multi-selector steps use selectors blocks only.
+			if len(checkStep.Selectors) <= 1 {
+				selectorType, selector := selectorFieldsFromSelectors(checkStep.Selectors)
+				if selector != "" {
+					cl["selector"] = selector
+				}
+				if selectorType != "" {
+					cl["selector_type"] = selectorType
+				}
 			}
 
 			if checkStep.OptionSelectorType != "" {
@@ -1061,10 +1162,6 @@ func flattenStepsData(checkSteps *[]sc2.StepsV2) []interface{} {
 
 			if checkStep.Value != "" {
 				cl["value"] = string(checkStep.Value)
-			}
-
-			if checkStep.SelectorType != "" {
-				cl["selector_type"] = checkStep.SelectorType
 			}
 
 			if checkStep.Duration != 0 {
@@ -1418,7 +1515,7 @@ func buildApiV2Data(d *schema.ResourceData) sc2.ApiCheckV2Input {
 	return apiv2
 }
 
-func buildBrowserV2Data(d *schema.ResourceData) sc2.BrowserCheckV2Input {
+func buildBrowserV2Data(d *schema.ResourceData) (sc2.BrowserCheckV2Input, error) {
 	var browserv2 sc2.BrowserCheckV2Input
 	browserv2Data := d.Get("test").([]interface{})
 	for _, browser := range browserv2Data {
@@ -1430,7 +1527,11 @@ func buildBrowserV2Data(d *schema.ResourceData) sc2.BrowserCheckV2Input {
 			browserv2.Test.Automaticretries = browser["automatic_retries"].(int)
 			browserv2.Test.LocationIds = buildLocationIdData(browser["location_ids"].([]interface{}))
 			browserv2.Test.Name = browser["name"].(string)
-			browserv2.Test.Transactions = buildBusinessTransactionsData(browser["transactions"].([]interface{}))
+			transactions, err := buildBusinessTransactionsData(browser["transactions"].([]interface{}))
+			if err != nil {
+				return browserv2, err
+			}
+			browserv2.Test.Transactions = transactions
 			browserv2.Test.Schedulingstrategy = browser["scheduling_strategy"].(string)
 			browserv2.Test.Advancedsettings = buildAdvancedSettingsData(browser["advanced_settings"].(*schema.Set))
 			browserv2.Test.Customproperties = buildCustomPropertiesData(browser["custom_properties"].(*schema.Set))
@@ -1438,7 +1539,7 @@ func buildBrowserV2Data(d *schema.ResourceData) sc2.BrowserCheckV2Input {
 	}
 
 	log.Println("[DEBUG] build browserv2 data:", browserv2)
-	return browserv2
+	return browserv2, nil
 }
 
 func buildHttpV2Data(d *schema.ResourceData) sc2.HttpCheckV2Input {
@@ -1601,17 +1702,21 @@ func buildRequestsData(requests []interface{}) []sc2.Requests {
 	return requestsList
 }
 
-func buildBusinessTransactionsData(businessTransactions []interface{}) []sc2.Transactions {
+func buildBusinessTransactionsData(businessTransactions []interface{}) ([]sc2.Transactions, error) {
 	businessTransactionsList := make([]sc2.Transactions, len(businessTransactions))
 	for i, bisTrans := range businessTransactions {
 		bisTrans := bisTrans.(map[string]interface{})
+		steps, err := buildStepV2Data(bisTrans["steps"].([]interface{}))
+		if err != nil {
+			return nil, err
+		}
 		transaction := sc2.Transactions{
 			Name:    bisTrans["name"].(string),
-			StepsV2: buildStepV2Data(bisTrans["steps"].([]interface{})),
+			StepsV2: steps,
 		}
 		businessTransactionsList[i] = transaction
 	}
-	return businessTransactionsList
+	return businessTransactionsList, nil
 }
 
 func buildHttpHeadersData(httpHeaders *schema.Set) []sc2.HttpHeaders {
@@ -1647,10 +1752,14 @@ func buildCustomPropertiesData(customProperties *schema.Set) []sc2.CustomPropert
 	return customPropertiesList
 }
 
-func buildStepV2Data(steps []interface{}) []sc2.StepsV2 {
+func buildStepV2Data(steps []interface{}) ([]sc2.StepsV2, error) {
 	stepsList := make([]sc2.StepsV2, len(steps))
 	for i, step := range steps {
 		step := step.(map[string]interface{})
+		selectors, err := buildSelectorsFromStep(step)
+		if err != nil {
+			return nil, err
+		}
 		st := sc2.StepsV2{
 			URL:                step["url"].(string),
 			Name:               step["name"].(string),
@@ -1658,8 +1767,7 @@ func buildStepV2Data(steps []interface{}) []sc2.StepsV2 {
 			WaitForNav:         step["wait_for_nav"].(bool),
 			WaitForNavTimeout:  step["wait_for_nav_timeout"].(int),
 			MaxWaitTime:        step["max_wait_time"].(int),
-			SelectorType:       step["selector_type"].(string),
-			Selector:           step["selector"].(string),
+			Selectors:          selectors,
 			OptionSelectorType: step["option_selector_type"].(string),
 			OptionSelector:     step["option_selector"].(string),
 			VariableName:       step["variable_name"].(string),
@@ -1669,7 +1777,7 @@ func buildStepV2Data(steps []interface{}) []sc2.StepsV2 {
 		stepsList[i] = st
 
 	}
-	return stepsList
+	return stepsList, nil
 }
 
 func buildSetupData(setups []interface{}) []sc2.Setup {

--- a/synthetics/structures_test.go
+++ b/synthetics/structures_test.go
@@ -62,6 +62,25 @@ func TestBuildSelectorsFromStep_legacyFields(t *testing.T) {
 	}
 }
 
+func TestDropStaleStepSelectors_legacyUpdateWins(t *testing.T) {
+	step := map[string]interface{}{
+		"name":          "06 Select-Val-Val",
+		"selector_type": "id",
+		"selector":      "valz",
+		"selectors": []interface{}{
+			map[string]interface{}{"type": "id", "value": "beep"},
+		},
+	}
+	dropStaleStepSelectors(step)
+	got, err := buildSelectorsFromStep(step)
+	if err != nil {
+		t.Fatalf("buildSelectorsFromStep() error = %v", err)
+	}
+	if len(got) != 1 || got[0].Value != "valz" {
+		t.Fatalf("selectors = %+v, want id/valz after dropping stale state", got)
+	}
+}
+
 func TestBuildSelectorsFromStep_prefersSelectorsList(t *testing.T) {
 	step := map[string]interface{}{
 		"selector_type": "id",
@@ -80,7 +99,7 @@ func TestBuildSelectorsFromStep_prefersSelectorsList(t *testing.T) {
 	}
 }
 
-func TestFlattenStepsData_singleSelectorUsesLegacyOnly(t *testing.T) {
+func TestFlattenStepsData_singleSelectorUsesSelectorsBlock(t *testing.T) {
 	steps := []sc2.StepsV2{{
 		Name:      "click",
 		Type:      "click_element",
@@ -92,11 +111,44 @@ func TestFlattenStepsData_singleSelectorUsesLegacyOnly(t *testing.T) {
 		t.Fatalf("len(steps) = %d, want 1", len(got))
 	}
 	step := got[0].(map[string]interface{})
-	if _, ok := step["selectors"]; ok {
-		t.Fatal("expected no selectors block for single selector")
+	selectors, ok := step["selectors"].([]interface{})
+	if !ok || len(selectors) != 1 {
+		t.Fatalf("selectors = %#v, want one block", step["selectors"])
 	}
-	if step["selector"] != "#order" || step["selector_type"] != "id" {
-		t.Fatalf("legacy fields = %v / %v, want #order / id", step["selector"], step["selector_type"])
+	sel := selectors[0].(map[string]interface{})
+	if sel["type"] != "id" || sel["value"] != "#order" {
+		t.Fatalf("selector block = %#v, want id/#order", sel)
+	}
+	if _, ok := step["selector"]; ok {
+		t.Fatal("expected no legacy selector field for single API selector")
+	}
+	if _, ok := step["selector_type"]; ok {
+		t.Fatal("expected no legacy selector_type for single API selector")
+	}
+}
+
+func TestStepSelectorInputsEquivalent_legacyAndSelectorsBlock(t *testing.T) {
+	oldIn := stepSelectorInput{
+		selectorType: "id",
+		selector:     "#order",
+	}
+	newIn := stepSelectorInput{
+		selectors: []sc2.Selector{{Type: "id", Value: "#order"}},
+	}
+	if !stepSelectorInputsEquivalent(oldIn, newIn) {
+		t.Fatal("expected legacy and single selectors block to be equivalent")
+	}
+	if !migratingFromLegacyToSelectors(oldIn, newIn) {
+		t.Fatal("expected legacy state to selectors config to be a migration")
+	}
+}
+
+func TestMigratingFromLegacyToSelectors_afterApplyNotMigration(t *testing.T) {
+	in := stepSelectorInput{
+		selectors: []sc2.Selector{{Type: "id", Value: "#order"}},
+	}
+	if migratingFromLegacyToSelectors(in, in) {
+		t.Fatal("selectors in state and config should not be treated as migration")
 	}
 }
 

--- a/synthetics/structures_test.go
+++ b/synthetics/structures_test.go
@@ -1,0 +1,138 @@
+// Copyright 2021 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package synthetics
+
+import (
+	"testing"
+
+	sc2 "github.com/splunk/syntheticsclient/v2/syntheticsclientv2"
+)
+
+func TestBuildSelectorsFromStep_multipleSelectors(t *testing.T) {
+	step := map[string]interface{}{
+		"name": "Click submit",
+		"selectors": []interface{}{
+			map[string]interface{}{"type": "css", "value": ".primary"},
+			map[string]interface{}{"type": "id", "value": "submit-btn"},
+		},
+	}
+
+	got, err := buildSelectorsFromStep(step)
+	if err != nil {
+		t.Fatalf("buildSelectorsFromStep() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(selectors) = %d, want 2", len(got))
+	}
+	if got[0].Type != "css" || got[0].Value != ".primary" {
+		t.Fatalf("first selector = %+v, want css/.primary", got[0])
+	}
+	if got[1].Type != "id" || got[1].Value != "submit-btn" {
+		t.Fatalf("second selector = %+v, want id/submit-btn", got[1])
+	}
+}
+
+func TestBuildSelectorsFromStep_legacyFields(t *testing.T) {
+	step := map[string]interface{}{
+		"selector_type": "id",
+		"selector":      "checkout-btn",
+	}
+
+	got, err := buildSelectorsFromStep(step)
+	if err != nil {
+		t.Fatalf("buildSelectorsFromStep() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("len(selectors) = %d, want 1", len(got))
+	}
+	if got[0].Type != "id" || got[0].Value != "checkout-btn" {
+		t.Fatalf("selector = %+v", got[0])
+	}
+}
+
+func TestBuildSelectorsFromStep_prefersSelectorsList(t *testing.T) {
+	step := map[string]interface{}{
+		"selector_type": "id",
+		"selector":      "ignored",
+		"selectors": []interface{}{
+			map[string]interface{}{"type": "css", "value": ".btn"},
+		},
+	}
+
+	got, err := buildSelectorsFromStep(step)
+	if err != nil {
+		t.Fatalf("buildSelectorsFromStep() error = %v", err)
+	}
+	if len(got) != 1 || got[0].Value != ".btn" {
+		t.Fatalf("selectors = %+v, want only .btn from selectors list", got)
+	}
+}
+
+func TestFlattenStepsData_singleSelectorUsesLegacyOnly(t *testing.T) {
+	steps := []sc2.StepsV2{{
+		Name:      "click",
+		Type:      "click_element",
+		Selectors: []sc2.Selector{{Type: "id", Value: "#order"}},
+	}}
+
+	got := flattenStepsData(&steps)
+	if len(got) != 1 {
+		t.Fatalf("len(steps) = %d, want 1", len(got))
+	}
+	step := got[0].(map[string]interface{})
+	if _, ok := step["selectors"]; ok {
+		t.Fatal("expected no selectors block for single selector")
+	}
+	if step["selector"] != "#order" || step["selector_type"] != "id" {
+		t.Fatalf("legacy fields = %v / %v, want #order / id", step["selector"], step["selector_type"])
+	}
+}
+
+func TestFlattenStepsData_multipleSelectorsExposed(t *testing.T) {
+	steps := []sc2.StepsV2{{
+		Name: "click",
+		Type: "click_element",
+		Selectors: []sc2.Selector{
+			{Type: "css", Value: ".primary"},
+			{Type: "id", Value: "submit-btn"},
+		},
+	}}
+
+	got := flattenStepsData(&steps)
+	step := got[0].(map[string]interface{})
+	selectors, ok := step["selectors"].([]interface{})
+	if !ok || len(selectors) != 2 {
+		t.Fatalf("selectors = %#v, want 2 blocks", step["selectors"])
+	}
+	if _, ok := step["selector"]; ok {
+		t.Fatal("expected no legacy selector fields for multiple selectors")
+	}
+	if _, ok := step["selector_type"]; ok {
+		t.Fatal("expected no legacy selector_type for multiple selectors")
+	}
+}
+
+func TestBuildSelectorsFromStep_tooManySelectors(t *testing.T) {
+	selectors := make([]interface{}, browserCheckV2MaxSelectors+1)
+	for i := range selectors {
+		selectors[i] = map[string]interface{}{"type": "id", "value": "x"}
+	}
+	step := map[string]interface{}{"selectors": selectors}
+
+	_, err := buildSelectorsFromStep(step)
+	if err == nil {
+		t.Fatal("expected error for too many selectors")
+	}
+}

--- a/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/common_models.go
+++ b/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/common_models.go
@@ -87,24 +87,29 @@ type BusinessTransactions struct {
 	StepsV2 []StepsV2 `json:"steps"`
 }
 
+// Selector is a v2 browser step element locator (type + value).
+type Selector struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
+}
+
 type StepsV2 struct {
-	Name                     string  `json:"name"`
-	Type                     string  `json:"type"`
-	URL                      string  `json:"url,omitempty"`
-	Action                   string  `json:"action,omitempty"`
-	WaitForNav               bool    `json:"waitForNav"`
-	WaitForNavTimeout        int     `json:"waitForNavTimeout,omitempty"`
-	WaitForNavTimeoutDefault bool    `json:"waitForNavTimeoutDefault,omitempty"`
-	MaxWaitTime              int     `json:"maxWaitTime,omitempty"`
-	MaxWaitTimeDefault       bool    `json:"maxWaitTimeDefault,omitempty"`
-	SelectorType             string  `json:"selectorType,omitempty"`
-	Selector                 string  `json:"selector,omitempty"`
-	OptionSelectorType       string  `json:"optionSelectorType,omitempty"`
-	OptionSelector           string  `json:"optionSelector,omitempty"`
-	VariableName             string  `json:"variableName,omitempty"`
-	Value                    string  `json:"value,omitempty"`
-	Options                  Options `json:"options,omitempty"`
-	Duration                 int     `json:"duration,omitempty"`
+	Name                     string     `json:"name"`
+	Type                     string     `json:"type"`
+	URL                      string     `json:"url,omitempty"`
+	Action                   string     `json:"action,omitempty"`
+	WaitForNav               bool       `json:"waitForNav"`
+	WaitForNavTimeout        int        `json:"waitForNavTimeout,omitempty"`
+	WaitForNavTimeoutDefault bool       `json:"waitForNavTimeoutDefault,omitempty"`
+	MaxWaitTime              int        `json:"maxWaitTime,omitempty"`
+	MaxWaitTimeDefault       bool       `json:"maxWaitTimeDefault,omitempty"`
+	Selectors                []Selector `json:"selectors,omitempty"`
+	OptionSelectorType       string     `json:"optionSelectorType,omitempty"`
+	OptionSelector           string     `json:"optionSelector,omitempty"`
+	VariableName             string     `json:"variableName,omitempty"`
+	Value                    string     `json:"value,omitempty"`
+	Options                  Options    `json:"options,omitempty"`
+	Duration                 int        `json:"duration,omitempty"`
 }
 
 type Options struct {
@@ -416,9 +421,9 @@ type ApiCheckV2Input struct {
 
 type ApiCheckV2Response struct {
 	Test struct {
-		Active             bool      `json:"active"`
-		Createdat          time.Time `json:"createdAt"`
-		Device             `json:"device,omitempty"`
+		Active             bool               `json:"active"`
+		Createdat          time.Time          `json:"createdAt"`
+		Deviceid           int                `json:"deviceId,omitempty"`
 		Frequency          int                `json:"frequency,omitempty"`
 		ID                 int                `json:"id,omitempty"`
 		Locationids        []string           `json:"locationIds,omitempty"`
@@ -460,8 +465,8 @@ type BrowserCheckV2Response struct {
 type BrowserCheckV2ResponseTest struct {
 	Active             bool `json:"active"`
 	Advancedsettings   `json:"advancedSettings"`
-	Createdat          time.Time `json:"createdAt"`
-	Device             `json:"device"`
+	Createdat          time.Time          `json:"createdAt"`
+	Deviceid           int                `json:"deviceId"`
 	Frequency          int                `json:"frequency"`
 	ID                 int                `json:"id"`
 	Locationids        []string           `json:"locationIds"`

--- a/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/create_apicheckv2.go
+++ b/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/create_apicheckv2.go
@@ -47,7 +47,7 @@ func (c Client) CreateApiCheckV2(ApiCheckV2Details *ApiCheckV2Input) (*ApiCheckV
 		return nil, nil, err
 	}
 
-	details, err := c.makePublicAPICall("POST", "/tests/api", bytes.NewBuffer(body), nil)
+	details, err := c.makePublicAPICall("POST", "/v2/tests/api", bytes.NewBuffer(body), nil)
 	if err != nil {
 		return nil, details, err
 	}

--- a/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/create_browsercheckv2.go
+++ b/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/create_browsercheckv2.go
@@ -38,7 +38,7 @@ func (c Client) CreateBrowserCheckV2(browserCheckV2Details *BrowserCheckV2Input)
 		return nil, nil, err
 	}
 
-	details, err := c.makePublicAPICall("POST", "/tests/browser", bytes.NewBuffer(body), nil)
+	details, err := c.makePublicAPICall("POST", "/v2/tests/browser", bytes.NewBuffer(body), nil)
 	if err != nil {
 		return nil, details, err
 	}

--- a/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/delete_apicheckv2.go
+++ b/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/delete_apicheckv2.go
@@ -22,7 +22,7 @@ import (
 )
 
 func (c Client) DeleteApiCheckV2(id int) (int, error) {
-	requestDetails, err := c.makePublicAPICall("DELETE", fmt.Sprintf("/tests/api/%d", id), bytes.NewBufferString("{}"), nil)
+	requestDetails, err := c.makePublicAPICall("DELETE", fmt.Sprintf("/v2/tests/api/%d", id), bytes.NewBufferString("{}"), nil)
 	if err != nil {
 		return 1, err
 	}

--- a/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/delete_browsercheckv2.go
+++ b/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/delete_browsercheckv2.go
@@ -22,7 +22,7 @@ import (
 )
 
 func (c Client) DeleteBrowserCheckV2(id int) (int, error) {
-	requestDetails, err := c.makePublicAPICall("DELETE", fmt.Sprintf("/tests/browser/%d", id), bytes.NewBufferString("{}"), nil)
+	requestDetails, err := c.makePublicAPICall("DELETE", fmt.Sprintf("/v2/tests/browser/%d", id), bytes.NewBufferString("{}"), nil)
 	if err != nil {
 		return 1, err
 	}

--- a/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/get_apicheckv2.go
+++ b/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/get_apicheckv2.go
@@ -34,7 +34,7 @@ func parseApiCheckV2Response(response string) (*ApiCheckV2Response, error) {
 func (c Client) GetApiCheckV2(id int) (*ApiCheckV2Response, *RequestDetails, error) {
 
 	details, err := c.makePublicAPICall("GET",
-		fmt.Sprintf("/tests/api/%d", id),
+		fmt.Sprintf("/v2/tests/api/%d", id),
 		bytes.NewBufferString("{}"),
 		nil)
 

--- a/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/get_browsercheckv2.go
+++ b/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/get_browsercheckv2.go
@@ -32,7 +32,7 @@ func parseGetBrowserCheckV2Response(response string) (*BrowserCheckV2Response, e
 }
 
 func (c Client) GetBrowserCheckV2(id int) (*BrowserCheckV2Response, *RequestDetails, error) {
-	details, err := c.makePublicAPICall("GET", fmt.Sprintf("/tests/browser/%d", id), bytes.NewBufferString("{}"), nil)
+	details, err := c.makePublicAPICall("GET", fmt.Sprintf("/v2/tests/browser/%d", id), bytes.NewBufferString("{}"), nil)
 
 	// Check for errors
 	if err != nil {

--- a/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/get_checksv2.go
+++ b/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/get_checksv2.go
@@ -108,7 +108,7 @@ func integersQueryParam(params []int, queryParamName string) string {
 	if len(params) == 0 {
 		return ""
 	}
-	return queryParamName + strings.Trim(strings.Replace(fmt.Sprint(params), " ", queryParamName, -1), "[]")
+	return queryParamName + strings.Trim(strings.ReplaceAll(fmt.Sprint(params), " ", queryParamName), "[]")
 }
 
 func stringsQueryParam(params []string, queryParamName string) string {

--- a/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/synthetics.go
+++ b/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/synthetics.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"time"
@@ -111,7 +110,7 @@ func (c Client) makePublicAPICall(method string, endpoint string, requestBody io
 		return &details, fmt.Errorf("unknown error, status code: %d", resp.StatusCode)
 	}
 
-	responseBody, err := ioutil.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return &details, err
 	}

--- a/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/update_apicheckv2.go
+++ b/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/update_apicheckv2.go
@@ -48,7 +48,7 @@ func (c Client) UpdateApiCheckV2(id int, ApiCheckV2Details *ApiCheckV2Input) (*A
 		return nil, nil, err
 	}
 
-	requestDetails, err := c.makePublicAPICall("PUT", fmt.Sprintf("/tests/api/%d", id), bytes.NewBuffer(body), nil)
+	requestDetails, err := c.makePublicAPICall("PUT", fmt.Sprintf("/v2/tests/api/%d", id), bytes.NewBuffer(body), nil)
 	if err != nil {
 		return nil, requestDetails, err
 	}

--- a/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/update_browsercheckv2.go
+++ b/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/update_browsercheckv2.go
@@ -39,7 +39,7 @@ func (c Client) UpdateBrowserCheckV2(id int, BrowserCheckV2Details *BrowserCheck
 		return nil, nil, err
 	}
 
-	requestDetails, err := c.makePublicAPICall("PUT", fmt.Sprintf("/tests/browser/%d", id), bytes.NewBuffer(body), nil)
+	requestDetails, err := c.makePublicAPICall("PUT", fmt.Sprintf("/v2/tests/browser/%d", id), bytes.NewBuffer(body), nil)
 	if err != nil {
 		return nil, requestDetails, err
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -175,8 +175,8 @@ github.com/oklog/run
 # github.com/splunk/syntheticsclient v1.0.3
 ## explicit; go 1.14
 github.com/splunk/syntheticsclient/syntheticsclient
-# github.com/splunk/syntheticsclient/v2 v2.0.17
-## explicit; go 1.14
+# github.com/splunk/syntheticsclient/v2 v2.1.0
+## explicit; go 1.16
 github.com/splunk/syntheticsclient/v2/syntheticsclientv2
 # github.com/vmihailenco/msgpack v4.0.4+incompatible
 ## explicit


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are expected for bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?

- Provider depended on github.com/splunk/syntheticsclient/v2 v2.0.x, which modeled browser steps with a single selector + selector_type and a nested device object on check responses.
- Browser check v2 steps only exposed legacy selector / selector_type in Terraform; there was no way to configure the API’s selectors array (multiple fallbacks per step).
- Read logic did not align read/write representations, which could cause perpetual plan drift when config and state used different shapes (legacy fields vs selectors blocks).
- API v2 checks used older response shapes for device metadata on read/flatten paths.

### After the change?

#### Dependency & API alignment

- Bump syntheticsclient/v2 to v2.1.0 and vendor updated client models (Deviceid, step Selectors[], etc.).
- Device handling updated for v2.1.0: use device_id from API Deviceid; enrich optional device block from the devices list on read (API + browser data sources).

#### Browser check v2 — multiselectors

- Browser check v2 steps support a nested selectors block (type + value, up to 10 per step), matching the v2 API.
- Backward-compatible legacy fields remain:
- Write: if selectors is non-empty, it wins; otherwise selector / selector_type are sent as a one-element array.
- If both legacy and a single stale selectors entry exist in merged state (common on step-index updates), dropStaleStepSelectors clears the stale block so legacy/config values apply.

#### Browser check v2 — read & plan behavior

- Read: all API selectors (including a single one) are persisted as selectors blocks in state (not legacy fields). Legacy fields are only written when the API returns no selectors.
- DiffSuppressFunc on selector, selector_type, and selectors suppresses cosmetic drift when state and config describe the same single selector in different shapes.
- Exception: suppression does not apply for the one-time migration legacy in state → single selectors block in config, so that change still shows in plan.
- After apply, config that keeps a single selectors { } block should stay in sync with state (no ongoing drift for unchanged selectors).

#### Schema, docs & examples

- Step schema helpers consolidated in resource_browser_check_v2.go (browserCheckV2StepSchema, browserCheckV2SelectorSchema).
- Docs/examples regenerated/updated (tfplugindocs, create_browser_check_v2.md, browser_v2_check.md, example with two selectors on a click step).

#### Tests

- Unit tests (structures_test.go): buildSelectorsFromStep, flattenStepsData, selector equivalence/migration helpers, dropStaleStepSelectors.
- Acceptance tests (resource_browser_check_v2_test.go): multiselector steps; state checks use selectors blocks for single selectors (testAccCheckBrowserV2SingleSelector); update config uses explicit selectors where values change at the same step index.

### Pull request checklist 
- [x] Acceptance Tests have been updated, run (`make testacc`), and pasted in this PR (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

#### Acceptance Test Output
<!-- Please paste the results of acceptance tests `make testacc` in the codeblock here. -->
```
➜  terraform-provider-synthetics git:(SYN-6219) ✗ make testacc TESTARGS='-run TestAcc.*V2' | tee /tmp/testacc-v2.log 
TF_ACC=1 go test $(go list ./... | grep -v 'vendor') -run TestAcc.*V2 -timeout 120m   | sed '/X-Sf-Token/d'
?       github.com/splunk/terraform-provider-synthetics [no test files]
ok      github.com/splunk/terraform-provider-synthetics/synthetics      (cached)
```

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

- [ ] Yes
- [x] No

----
