### PR TITLE
fix: lastRunId is a UUID in SSL tests

### DIFF
--- a/docs/data-sources/ssl_v2_check.md
+++ b/docs/data-sources/ssl_v2_check.md
@@ -52,7 +52,7 @@ Read-Only:
 - `host` (String)
 - `last_run_at` (String)
 - `last_run_core_metrics_published_at` (String)
-- `last_run_id` (Number)
+- `last_run_id` (String)
 - `last_run_location_id` (String)
 - `last_run_status` (String)
 - `location_ids` (List of String)

--- a/docs/resources/create_ssl_check_v2.md
+++ b/docs/resources/create_ssl_check_v2.md
@@ -77,7 +77,7 @@ Read-Only:
 - `id` (Number)
 - `last_run_at` (String)
 - `last_run_core_metrics_published_at` (String)
-- `last_run_id` (Number)
+- `last_run_id` (String)
 - `last_run_location_id` (String)
 - `last_run_status` (String)
 - `updated_at` (String)

--- a/synthetics/resource_ssl_check_v2.go
+++ b/synthetics/resource_ssl_check_v2.go
@@ -85,7 +85,7 @@ func sslCheckV2ResourceTestSchema() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"last_run_id": {
-			Type:     schema.TypeInt,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
 		"last_run_core_metrics_published_at": {
@@ -206,7 +206,7 @@ func sslCheckV2DataSourceTestSchema() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"last_run_id": {
-			Type:     schema.TypeInt,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
 		"last_run_core_metrics_published_at": {

--- a/synthetics/structures.go
+++ b/synthetics/structures.go
@@ -1081,7 +1081,7 @@ func flattenSslCheckV2Read(checkSslV2 *sc2.SslCheckV2Response) []interface{} {
 		sslV2["last_run_location_id"] = checkSslV2.Test.LastRunLocationId
 	}
 
-	if checkSslV2.Test.LastRunId != 0 {
+	if checkSslV2.Test.LastRunId != "" {
 		sslV2["last_run_id"] = checkSslV2.Test.LastRunId
 	}
 

--- a/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/common_models.go
+++ b/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/common_models.go
@@ -502,7 +502,7 @@ type SslCheckV2Response struct {
 		Lastrunat                     time.Time          `json:"lastRunAt"`
 		LastRunCoreMetricsPublishedAt time.Time          `json:"lastRunCoreMetricsPublishedAt"`
 		LastRunLocationId             string             `json:"lastRunLocationId"`
-		LastRunId                     int                `json:"lastRunId"`
+		LastRunId                     string             `json:"lastRunId"`
 		Automaticretries              int                `json:"automaticRetries"`
 		Createdby                     string             `json:"createdBy"`
 		Updatedby                     string             `json:"updatedBy"`


### PR DESCRIPTION
The SignalFX API returns a UUID in the lastRunId field of an SSL test. The provider expects an int. This breaks the terraform apply.