### PR TITLE
Fix agreement checks with Splunk reusable workflow

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -16,12 +16,12 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        uses: contributor-assistant/github-action@v2.3.0
+        # v2.6.1 with only the action runtime upgraded from Node 20 to Node 24.
+        uses: OpenMapX/cla-assistant-action@3e864d0e9c7ec7a7fc4eb36e78ff857b1db7978c # v2.6.1-node24
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # the below token should have repo scope and must be manually added by you in the repository's secret
-          # This token is required only if you have configured to store the signatures in a remote repository/organization
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          # Splunk-managed token with write access to the remote signatures repository.
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PAT_CLATOOL }}
         with:
           path-to-signatures: 'signatures/version1/cla.json'
           path-to-document: 'https://github.com/splunk/cla-agreement/blob/main/CLA.md' # e.g. a CLA or a DCO document
@@ -35,10 +35,11 @@ jobs:
     steps:
       - name: "COC Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the Code of Conduct and I hereby accept the Terms') || github.event_name == 'pull_request_target'
-        uses: cla-assistant/github-action@v2.3.0
+        # v2.6.1 with only the action runtime upgraded from Node 20 to Node 24.
+        uses: OpenMapX/cla-assistant-action@3e864d0e9c7ec7a7fc4eb36e78ff857b1db7978c # v2.6.1-node24
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PAT_CLATOOL }}
         with:
           path-to-signatures: "signatures/version1/coc.json"
           path-to-document: "https://github.com/splunk/cla-agreement/blob/main/CODE_OF_CONDUCT.md" # e.g. a COC or a DCO document

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -4,51 +4,15 @@ on:
     types: [created]
   pull_request_target:
     types: [opened, closed, synchronize]
-# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
-permissions:
-  actions: write
-  contents: write
-  pull-requests: write
-  statuses: write
+
 jobs:
-  CLAAssistant:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "CLA Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-        # v2.6.1 with only the action runtime upgraded from Node 20 to Node 24.
-        uses: OpenMapX/cla-assistant-action@3e864d0e9c7ec7a7fc4eb36e78ff857b1db7978c # v2.6.1-node24
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Splunk-managed token with write access to the remote signatures repository.
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PAT_CLATOOL }}
-        with:
-          path-to-signatures: 'signatures/version1/cla.json'
-          path-to-document: 'https://github.com/splunk/cla-agreement/blob/main/CLA.md' # e.g. a CLA or a DCO document
-          # branch should not be protected
-          branch: 'main'
-          allowlist: dependabot[bot]
-          remote-organization-name: splunk
-          remote-repository-name: cla-agreement
-  CodeOfConduct:
-    runs-on: ubuntu-latest
-    steps:
-      - name: "COC Assistant"
-        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the Code of Conduct and I hereby accept the Terms') || github.event_name == 'pull_request_target'
-        # v2.6.1 with only the action runtime upgraded from Node 20 to Node 24.
-        uses: OpenMapX/cla-assistant-action@3e864d0e9c7ec7a7fc4eb36e78ff857b1db7978c # v2.6.1-node24
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.PAT_CLATOOL }}
-        with:
-          path-to-signatures: "signatures/version1/coc.json"
-          path-to-document: "https://github.com/splunk/cla-agreement/blob/main/CODE_OF_CONDUCT.md" # e.g. a COC or a DCO document
-          branch: "main"
-          allowlist: dependabot[bot]
-          remote-organization-name: splunk
-          remote-repository-name: cla-agreement
-          custom-pr-sign-comment: "I have read the Code of Conduct and I hereby accept the Terms"
-          create-file-commit-message: "For example: Creating file for storing COC Signatures"
-          signed-commit-message: "$contributorName has signed the COC in #$pullRequestNo"
-          custom-notsigned-prcomment: "All contributors have NOT signed the COC Document"
-          custom-allsigned-prcomment: "****CLA Assistant Lite bot**** All contributors have signed the COC  ✍️ ✅"
+  call-workflow-agreements:
+    uses: splunk/addonfactory-github-workflows/.github/workflows/reusable-agreements.yaml@v1.7.2
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+      statuses: read
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PERSONAL_ACCESS_TOKEN: ${{ secrets.PAT_CLATOOL }}


### PR DESCRIPTION
## Summary

- replace the duplicated local CLA and Code of Conduct jobs with Splunk's reusable agreement workflow at `v1.7.2`
- pass the standard `PAT_CLATOOL` credential for the central `splunk/cla-agreement` signature files
- inherit the centrally maintained contributor-assistant upgrade, least-privilege permissions, and GitHub App token migration path

## Root cause

The agreement checks on #94 both fail while reading the remote signatures repository:

```
Could not retrieve repository contents. Status: 401
```

The local workflow supplies the legacy `PERSONAL_ACCESS_TOKEN` organization secret, which GitHub rejects. It also duplicates an old contributor-assistant v2.3.0 configuration that other Splunk repositories have replaced with the internal reusable workflow.

## Impact

This restores the shared Splunk CLA credential convention and delegates action/runtime maintenance to the versioned internal workflow without changing the central signature repository.

## Validation

- `actionlint v1.7.12 .github/workflows/cla.yaml`
- `git diff --check`
- compared the caller configuration with `splunk/splunk-connect-for-snmp`
- inspected `reusable-agreements.yaml@v1.7.2`, including its contributor-assistant v2.6.1 upgrade and App-token fallback

Because `pull_request_target` loads its workflow from the base branch, the updated agreement workflow can only be exercised after merge. A post-merge `recheck` on #94 will confirm that `PAT_CLATOOL` is available to this repository.
