### PR TITLE
SYN-6805: fix SSL last run ID handling

### DIFF
--- a/docs/data-sources/ssl_v2_check.md
+++ b/docs/data-sources/ssl_v2_check.md
@@ -52,7 +52,7 @@ Read-Only:
 - `host` (String)
 - `last_run_at` (String)
 - `last_run_core_metrics_published_at` (String)
-- `last_run_id` (Number)
+- `last_run_id` (String)
 - `last_run_location_id` (String)
 - `last_run_status` (String)
 - `location_ids` (List of String)

--- a/docs/resources/create_ssl_check_v2.md
+++ b/docs/resources/create_ssl_check_v2.md
@@ -77,7 +77,7 @@ Read-Only:
 - `id` (Number)
 - `last_run_at` (String)
 - `last_run_core_metrics_published_at` (String)
-- `last_run_id` (Number)
+- `last_run_id` (String)
 - `last_run_location_id` (String)
 - `last_run_status` (String)
 - `updated_at` (String)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/splunk/syntheticsclient v1.0.3
-	github.com/splunk/syntheticsclient/v2 v2.4.0
+	github.com/splunk/syntheticsclient/v2 v2.6.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -174,8 +174,8 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/splunk/syntheticsclient v1.0.3 h1:I3PUgTnKZsCNGFH8OgBiQ+sZYYxOwcLmkbi3mp0Qq78=
 github.com/splunk/syntheticsclient v1.0.3/go.mod h1:riH4plM9ySr2lHnWi2E4cocaP9qqlRQHKX6nisiyq6E=
-github.com/splunk/syntheticsclient/v2 v2.4.0 h1:Q8HLMK8iZRDYFKziaxpdPSiiqxnKz6KVMgYH/aPUlG0=
-github.com/splunk/syntheticsclient/v2 v2.4.0/go.mod h1:zW4yCT2gP3MLvUwf95UyBfQJLiSnrRLpufH+VF80Q/A=
+github.com/splunk/syntheticsclient/v2 v2.6.0 h1:36WrHlYAkf2QJVw2gzK2AMkmDutvFNw3hdcbZMp9unY=
+github.com/splunk/syntheticsclient/v2 v2.6.0/go.mod h1:zW4yCT2gP3MLvUwf95UyBfQJLiSnrRLpufH+VF80Q/A=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/synthetics/resource_ssl_check_v2.go
+++ b/synthetics/resource_ssl_check_v2.go
@@ -85,7 +85,7 @@ func sslCheckV2ResourceTestSchema() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"last_run_id": {
-			Type:     schema.TypeInt,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
 		"last_run_core_metrics_published_at": {
@@ -206,7 +206,7 @@ func sslCheckV2DataSourceTestSchema() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"last_run_id": {
-			Type:     schema.TypeInt,
+			Type:     schema.TypeString,
 			Computed: true,
 		},
 		"last_run_core_metrics_published_at": {

--- a/synthetics/resource_ssl_check_v2_test.go
+++ b/synthetics/resource_ssl_check_v2_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 const newSslCheckV2Config = `
@@ -117,6 +118,18 @@ func TestSslCheckV2AcceptanceConfigsOmitUnsupportedCertificateValidations(t *tes
 		}
 		if strings.Contains(config, "validations {") {
 			t.Fatalf("%s config must not send unsupported SSL certificate validations", name)
+		}
+	}
+}
+
+func TestSslCheckV2LastRunIDSchemaUsesString(t *testing.T) {
+	for name, testSchema := range map[string]map[string]*schema.Schema{
+		"resource":    sslCheckV2ResourceTestSchema(),
+		"data source": sslCheckV2DataSourceTestSchema(),
+	} {
+		lastRunIDSchema := testSchema["last_run_id"]
+		if lastRunIDSchema.Type != schema.TypeString {
+			t.Errorf("%s last_run_id type = %v, want TypeString", name, lastRunIDSchema.Type)
 		}
 	}
 }

--- a/synthetics/structures.go
+++ b/synthetics/structures.go
@@ -1081,7 +1081,7 @@ func flattenSslCheckV2Read(checkSslV2 *sc2.SslCheckV2Response) []interface{} {
 		sslV2["last_run_location_id"] = checkSslV2.Test.LastRunLocationId
 	}
 
-	if checkSslV2.Test.LastRunId != 0 {
+	if checkSslV2.Test.LastRunId != "" {
 		sslV2["last_run_id"] = checkSslV2.Test.LastRunId
 	}
 

--- a/synthetics/structures_test.go
+++ b/synthetics/structures_test.go
@@ -546,6 +546,23 @@ func TestFlattenSslCheckV2ReadPreservesNullableServerNameAndCaCertificateID(t *t
 	}
 }
 
+func TestFlattenSslCheckV2ReadPreservesUUIDLastRunID(t *testing.T) {
+	const lastRunID = "77ff08f0-3865-42d8-9fff-3efb7c25e176"
+	var check sc2.SslCheckV2Response
+	if err := json.Unmarshal([]byte(`{"test":{"lastRunId":"`+lastRunID+`"}}`), &check); err != nil {
+		t.Fatalf("unmarshal SSL response: %v", err)
+	}
+
+	got := flattenSslCheckV2Read(&check)
+	if len(got) != 1 {
+		t.Fatalf("len(flattened) = %d, want 1", len(got))
+	}
+	test := got[0].(map[string]interface{})
+	if test["last_run_id"] != lastRunID {
+		t.Fatalf("last_run_id = %#v, want %q", test["last_run_id"], lastRunID)
+	}
+}
+
 func TestBuildCaCertificateV2DataRequiresContent(t *testing.T) {
 	d := schema.TestResourceDataRaw(t, resourceCaCertificateV2().Schema, map[string]interface{}{
 		"ca_certificate": []interface{}{

--- a/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/common_models.go
+++ b/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/common_models.go
@@ -106,6 +106,7 @@ type Advancedsettings struct {
 	Verifycertificates        bool             `json:"verifyCertificates"`
 	ChromeFlags               []ChromeFlag     `json:"chromeFlags"`
 	ExcludedFiles             []ExcludedFile   `json:"excludedFiles"`
+	CertificateIDs            []int            `json:"certificateIds,omitempty"`
 }
 
 type ChromeFlag struct {
@@ -207,9 +208,10 @@ type Requests struct {
 type Configuration struct {
 	Body          string `json:"body"`
 	Headers       `json:"headers"`
-	Name          string `json:"name"`
-	RequestMethod string `json:"requestMethod,omitempty"`
-	URL           string `json:"url,omitempty"`
+	Name          string       `json:"name"`
+	RequestMethod string       `json:"requestMethod,omitempty"`
+	URL           string       `json:"url,omitempty"`
+	CertificateID *NullableInt `json:"certificateId,omitempty"`
 }
 
 type Headers map[string]interface{}
@@ -479,6 +481,87 @@ type CaCertificatesV2Response struct {
 	CaCerts []CaCertificate `json:"cacerts"`
 }
 
+type ClientCertificateKey struct {
+	ID            int       `json:"id,omitempty"`
+	Content       string    `json:"content,omitempty"`
+	Filename      string    `json:"filename,omitempty"`
+	FileExtension string    `json:"fileExtension,omitempty"`
+	CreatedAt     time.Time `json:"createdAt,omitempty"`
+	CreatedBy     string    `json:"createdBy,omitempty"`
+	UpdatedAt     time.Time `json:"updatedAt,omitempty"`
+	UpdatedBy     string    `json:"updatedBy,omitempty"`
+}
+
+type ClientCertificatePrivateKey struct {
+	ID            int       `json:"id,omitempty"`
+	Content       string    `json:"content,omitempty"`
+	Filename      string    `json:"filename,omitempty"`
+	FileExtension string    `json:"fileExtension,omitempty"`
+	Password      string    `json:"password,omitempty"`
+	CreatedAt     time.Time `json:"createdAt,omitempty"`
+	CreatedBy     string    `json:"createdBy,omitempty"`
+	UpdatedAt     time.Time `json:"updatedAt,omitempty"`
+	UpdatedBy     string    `json:"updatedBy,omitempty"`
+}
+
+type ClientCertificateKeyInput struct {
+	Content       string `json:"content"`
+	Filename      string `json:"filename"`
+	FileExtension string `json:"fileExtension"`
+}
+
+type ClientCertificatePrivateKeyInput struct {
+	Content       string `json:"content"`
+	Filename      string `json:"filename"`
+	FileExtension string `json:"fileExtension"`
+	Password      string `json:"password,omitempty"`
+}
+
+type ClientCertificate struct {
+	ID          int                         `json:"id,omitempty"`
+	Name        string                      `json:"name,omitempty"`
+	Description string                      `json:"description,omitempty"`
+	Domain      string                      `json:"domain,omitempty"`
+	ExpiresAt   time.Time                   `json:"expiresAt,omitempty"`
+	CreatedAt   time.Time                   `json:"createdAt,omitempty"`
+	CreatedBy   string                      `json:"createdBy,omitempty"`
+	UpdatedAt   time.Time                   `json:"updatedAt,omitempty"`
+	UpdatedBy   string                      `json:"updatedBy,omitempty"`
+	PublicKey   ClientCertificateKey        `json:"publicKey,omitempty"`
+	PrivateKey  ClientCertificatePrivateKey `json:"privateKey,omitempty"`
+}
+
+type ClientCertificateInput struct {
+	Name        string                           `json:"name"`
+	Description string                           `json:"description,omitempty"`
+	Domain      string                           `json:"domain"`
+	PublicKey   ClientCertificateKeyInput        `json:"publicKey"`
+	PrivateKey  ClientCertificatePrivateKeyInput `json:"privateKey"`
+}
+
+type ClientCertificateUpdateInput struct {
+	Description *string                           `json:"description,omitempty"`
+	Domain      *string                           `json:"domain,omitempty"`
+	PublicKey   *ClientCertificateKeyInput        `json:"publicKey,omitempty"`
+	PrivateKey  *ClientCertificatePrivateKeyInput `json:"privateKey,omitempty"`
+}
+
+type ClientCertificateV2Input struct {
+	Certificate ClientCertificateInput `json:"certificate"`
+}
+
+type ClientCertificateV2UpdateInput struct {
+	Certificate ClientCertificateUpdateInput `json:"certificate"`
+}
+
+type ClientCertificateV2Response struct {
+	Certificate ClientCertificate `json:"certificate"`
+}
+
+type ClientCertificatesV2Response struct {
+	Certificates []ClientCertificate `json:"certificates"`
+}
+
 type SslCheckV2Response struct {
 	Test struct {
 		ID                            int                `json:"id,omitempty"`
@@ -502,7 +585,7 @@ type SslCheckV2Response struct {
 		Lastrunat                     time.Time          `json:"lastRunAt"`
 		LastRunCoreMetricsPublishedAt time.Time          `json:"lastRunCoreMetricsPublishedAt"`
 		LastRunLocationId             string             `json:"lastRunLocationId"`
-		LastRunId                     int                `json:"lastRunId"`
+		LastRunId                     string             `json:"lastRunId"`
 		Automaticretries              int                `json:"automaticRetries"`
 		Createdby                     string             `json:"createdBy"`
 		Updatedby                     string             `json:"updatedBy"`
@@ -604,6 +687,7 @@ type HttpCheckV2Response struct {
 		Authentication     *Authentication    `json:"authentication"`
 		UserAgent          *string            `json:"userAgent"`
 		Verifycertificates bool               `json:"verifyCertificates"`
+		CertificateID      *NullableInt       `json:"certificateId,omitempty"`
 		HttpHeaders        []HttpHeaders      `json:"headers,omitempty"`
 		Validations        []Validations      `json:"validations"`
 		Customproperties   []CustomProperties `json:"customProperties"`
@@ -630,6 +714,7 @@ type HttpCheckV2Input struct {
 		Authentication     *Authentication    `json:"authentication"`
 		UserAgent          *string            `json:"userAgent"`
 		Verifycertificates bool               `json:"verifyCertificates"`
+		CertificateID      *NullableInt       `json:"certificateId,omitempty"`
 		HttpHeaders        []HttpHeaders      `json:"headers,omitempty"`
 		Validations        []Validations      `json:"validations"`
 		Customproperties   []CustomProperties `json:"customProperties"`
@@ -740,6 +825,52 @@ type BrowserCheckV2Input struct {
 		Customproperties   []CustomProperties `json:"customProperties"`
 		Automaticretries   int                `json:"automaticRetries"`
 	} `json:"test"`
+}
+
+func (b BrowserCheckV2Input) MarshalJSON() ([]byte, error) {
+	type advancedSettingsJSON struct {
+		Advancedsettings
+		CertificateIDs *[]int `json:"certificateIds,omitempty"`
+	}
+
+	type browserCheckV2InputTestJSON struct {
+		Name               string               `json:"name"`
+		Transactions       []Transactions       `json:"transactions"`
+		Urlprotocol        string               `json:"urlProtocol"`
+		Starturl           string               `json:"startUrl"`
+		LocationIds        []string             `json:"locationIds"`
+		DeviceID           int                  `json:"deviceId"`
+		Frequency          int                  `json:"frequency"`
+		Schedulingstrategy string               `json:"schedulingStrategy"`
+		Active             bool                 `json:"active"`
+		Advancedsettings   advancedSettingsJSON `json:"advancedSettings,omitempty"`
+		Customproperties   []CustomProperties   `json:"customProperties"`
+		Automaticretries   int                  `json:"automaticRetries"`
+	}
+
+	advancedSettings := advancedSettingsJSON{Advancedsettings: b.Test.Advancedsettings}
+	if b.Test.CertificateIDs != nil {
+		advancedSettings.CertificateIDs = &b.Test.CertificateIDs
+	}
+
+	return json.Marshal(struct {
+		Test browserCheckV2InputTestJSON `json:"test"`
+	}{
+		Test: browserCheckV2InputTestJSON{
+			Name:               b.Test.Name,
+			Transactions:       b.Test.Transactions,
+			Urlprotocol:        b.Test.Urlprotocol,
+			Starturl:           b.Test.Starturl,
+			LocationIds:        b.Test.LocationIds,
+			DeviceID:           b.Test.DeviceID,
+			Frequency:          b.Test.Frequency,
+			Schedulingstrategy: b.Test.Schedulingstrategy,
+			Active:             b.Test.Active,
+			Advancedsettings:   advancedSettings,
+			Customproperties:   b.Test.Customproperties,
+			Automaticretries:   b.Test.Automaticretries,
+		},
+	})
 }
 
 type BrowserCheckV2Response struct {

--- a/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/create_clientcertificatev2.go
+++ b/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/create_clientcertificatev2.go
@@ -1,0 +1,49 @@
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+func parseCreateClientCertificateV2Response(response string) (*ClientCertificateV2Response, error) {
+	var createClientCertificateV2 ClientCertificateV2Response
+	err := json.Unmarshal([]byte(response), &createClientCertificateV2)
+	if err != nil {
+		return nil, err
+	}
+
+	return &createClientCertificateV2, nil
+}
+
+func (c Client) CreateClientCertificateV2(input *ClientCertificateV2Input) (*ClientCertificateV2Response, *RequestDetails, error) {
+	body, err := json.Marshal(input)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	details, err := c.makePublicAPICall("POST", "/certificates", bytes.NewBuffer(body), nil)
+	if err != nil {
+		return nil, details, err
+	}
+
+	newClientCertificateV2, err := parseCreateClientCertificateV2Response(details.ResponseBody)
+	if err != nil {
+		return newClientCertificateV2, details, err
+	}
+
+	return newClientCertificateV2, details, nil
+}

--- a/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/delete_clientcertificatev2.go
+++ b/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/delete_clientcertificatev2.go
@@ -1,0 +1,37 @@
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+func (c Client) DeleteClientCertificateV2(id int) (int, error) {
+	details, err := c.makePublicAPICall("DELETE", fmt.Sprintf("/certificates/%d", id), bytes.NewBufferString("{}"), nil)
+	if err != nil {
+		return 1, err
+	}
+
+	status := details.StatusCode
+	if status >= 300 || status < 200 {
+		errorMsg := fmt.Sprintf("error: Response code %v. Expecting 2XX.", strconv.Itoa(status))
+		return status, errors.New(errorMsg)
+	}
+
+	return status, nil
+}

--- a/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/get_clientcertificatesv2.go
+++ b/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/get_clientcertificatesv2.go
@@ -1,0 +1,44 @@
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+func parseGetClientCertificatesV2Response(response string) (*ClientCertificatesV2Response, error) {
+	var clientCertificatesV2 ClientCertificatesV2Response
+	err := json.Unmarshal([]byte(response), &clientCertificatesV2)
+	if err != nil {
+		return nil, err
+	}
+
+	return &clientCertificatesV2, nil
+}
+
+func (c Client) GetClientCertificatesV2() (*ClientCertificatesV2Response, *RequestDetails, error) {
+	details, err := c.makePublicAPICall("GET", "/certificates", bytes.NewBufferString("{}"), nil)
+	if err != nil {
+		return nil, details, err
+	}
+
+	clientCertificatesV2, err := parseGetClientCertificatesV2Response(details.ResponseBody)
+	if err != nil {
+		return clientCertificatesV2, details, err
+	}
+
+	return clientCertificatesV2, details, nil
+}

--- a/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/get_clientcertificatev2.go
+++ b/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/get_clientcertificatev2.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+func parseGetClientCertificateV2Response(response string) (*ClientCertificateV2Response, error) {
+	var clientCertificateV2 ClientCertificateV2Response
+	err := json.Unmarshal([]byte(response), &clientCertificateV2)
+	if err != nil {
+		return nil, err
+	}
+
+	return &clientCertificateV2, nil
+}
+
+func (c Client) GetClientCertificateV2(id int) (*ClientCertificateV2Response, *RequestDetails, error) {
+	details, err := c.makePublicAPICall("GET", fmt.Sprintf("/certificates/%d", id), bytes.NewBufferString("{}"), nil)
+	if err != nil {
+		return nil, details, err
+	}
+
+	clientCertificateV2, err := parseGetClientCertificateV2Response(details.ResponseBody)
+	if err != nil {
+		return clientCertificateV2, details, err
+	}
+
+	return clientCertificateV2, details, nil
+}

--- a/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/synthetics.go
+++ b/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/synthetics.go
@@ -40,9 +40,13 @@ type ClientArgs struct {
 type RequestDetails struct {
 	StatusCode   int
 	ResponseBody string
-	RequestBody  string
-	RawResponse  *http.Response
-	RawRequest   *http.Request
+	// RequestBody is the supported debug representation of the outgoing request.
+	// It redacts API tokens and sensitive JSON values before being returned.
+	RequestBody string
+	RawResponse *http.Response
+	// RawRequest is intentionally not returned by v2 public API calls because it
+	// can retain authorization headers or request body secrets.
+	RawRequest *http.Request
 }
 
 type errorResponse struct {
@@ -56,6 +60,24 @@ type errorResponse struct {
 
 func (c Client) String() string {
 	return fmt.Sprintf("Splunk Synthetics Client: URL: %s ", c.publicBaseURL)
+}
+
+var sensitiveJSONFieldNames = map[string]struct{}{
+	"body":     {},
+	"content":  {},
+	"password": {},
+	"username": {},
+	"value":    {},
+}
+
+var sensitiveHeaderNames = map[string]struct{}{
+	"authorization":       {},
+	"proxy-authorization": {},
+	"cookie":              {},
+	"set-cookie":          {},
+	"x-sf-token":          {},
+	"x-api-key":           {},
+	"api-key":             {},
 }
 
 func (c Client) makePublicAPICall(method string, endpoint string, requestBody io.Reader, queryParams map[string]string) (*RequestDetails, error) {
@@ -79,8 +101,6 @@ func (c Client) makePublicAPICall(method string, endpoint string, requestBody io
 	}
 	req.URL.RawQuery = q.Encode()
 
-	// Add the request to the details
-	details.RawRequest = req
 	requestDump, err := httputil.DumpRequestOut(req, true)
 	if err != nil {
 		return &details, err
@@ -126,18 +146,40 @@ func redactSensitiveValue(value string, sensitiveValue string) string {
 	return strings.ReplaceAll(value, sensitiveValue, "[REDACTED]")
 }
 
-func sanitizeRequestDump(requestDump string, apiKey string, endpoint string) string {
+func sanitizeRequestDump(requestDump string, apiKey string, _ string) string {
 	sanitizedRequestDump := redactSensitiveValue(requestDump, apiKey)
-	if !strings.Contains(endpoint, "/cacerts") {
-		return sanitizedRequestDump
-	}
-
-	return redactCaCertificateContent(sanitizedRequestDump)
+	sanitizedRequestDump = redactRequestDumpURLQuery(sanitizedRequestDump)
+	return redactSensitiveRequestBody(sanitizedRequestDump)
 }
 
-func redactCaCertificateContent(requestDump string) string {
+func redactRequestDumpURLQuery(requestDump string) string {
+	lineEnd := strings.Index(requestDump, "\n")
+	if lineEnd == -1 {
+		return redactRequestLineURLQuery(requestDump)
+	}
+
+	return redactRequestLineURLQuery(requestDump[:lineEnd]) + requestDump[lineEnd:]
+}
+
+func redactRequestLineURLQuery(requestLine string) string {
+	lineSuffix := ""
+	if strings.HasSuffix(requestLine, "\r") {
+		requestLine = strings.TrimSuffix(requestLine, "\r")
+		lineSuffix = "\r"
+	}
+
+	requestLineParts := strings.SplitN(requestLine, " ", 3)
+	if len(requestLineParts) != 3 {
+		return requestLine + lineSuffix
+	}
+
+	requestLineParts[1] = redactURLQueryValues(requestLineParts[1])
+	return strings.Join(requestLineParts, " ") + lineSuffix
+}
+
+func redactSensitiveRequestBody(requestDump string) string {
 	headers, body, separator, ok := splitRequestDump(requestDump)
-	if !ok || body == "" {
+	if !ok || strings.TrimSpace(body) == "" {
 		return requestDump
 	}
 
@@ -146,7 +188,7 @@ func redactCaCertificateContent(requestDump string) string {
 		return replaceRequestDumpBody(headers, separator)
 	}
 
-	redactContentFields(requestBody)
+	redactSensitiveJSONFields(requestBody)
 
 	redactedRequestBody, err := json.Marshal(requestBody)
 	if err != nil {
@@ -171,21 +213,124 @@ func replaceRequestDumpBody(headers string, separator string) string {
 	return headers + separator + "[REDACTED]"
 }
 
-func redactContentFields(value interface{}) {
+func redactSensitiveJSONFields(value interface{}) {
 	switch typedValue := value.(type) {
 	case map[string]interface{}:
 		for key, nestedValue := range typedValue {
-			if strings.EqualFold(key, "content") {
+			if _, ok := sensitiveJSONFieldNames[strings.ToLower(key)]; ok {
 				typedValue[key] = "[REDACTED]"
 				continue
 			}
-			redactContentFields(nestedValue)
+			if isSensitiveHeaderName(key) {
+				typedValue[key] = "[REDACTED]"
+				continue
+			}
+			if isURLFieldName(key) {
+				if urlValue, ok := nestedValue.(string); ok {
+					typedValue[key] = redactURLQueryValues(urlValue)
+					continue
+				}
+			}
+			if strings.EqualFold(key, "headers") {
+				redactHeaderValues(nestedValue)
+				continue
+			}
+			redactSensitiveJSONFields(nestedValue)
 		}
 	case []interface{}:
 		for _, nestedValue := range typedValue {
-			redactContentFields(nestedValue)
+			redactSensitiveJSONFields(nestedValue)
 		}
 	}
+}
+
+func redactHeaderValues(value interface{}) {
+	switch typedValue := value.(type) {
+	case map[string]interface{}:
+		for key := range typedValue {
+			typedValue[key] = "[REDACTED]"
+		}
+	default:
+		redactSensitiveJSONFields(value)
+	}
+}
+
+func isSensitiveHeaderName(key string) bool {
+	lowerKey := strings.ToLower(key)
+	if _, ok := sensitiveHeaderNames[lowerKey]; ok {
+		return true
+	}
+
+	return strings.Contains(lowerKey, "token") ||
+		strings.Contains(lowerKey, "secret") ||
+		strings.Contains(lowerKey, "password")
+}
+
+func isURLFieldName(key string) bool {
+	lowerKey := strings.ToLower(key)
+	return lowerKey == "url" || strings.HasSuffix(lowerKey, "url")
+}
+
+func redactURLQueryValues(rawURL string) string {
+	redactedURL := redactURLUserinfo(rawURL)
+	queryStart := strings.Index(redactedURL, "?")
+	if queryStart == -1 || queryStart == len(redactedURL)-1 {
+		return redactedURL
+	}
+
+	prefix := redactedURL[:queryStart+1]
+	query := redactedURL[queryStart+1:]
+	fragment := ""
+	if fragmentStart := strings.Index(query, "#"); fragmentStart != -1 {
+		fragment = query[fragmentStart:]
+		query = query[:fragmentStart]
+	}
+	if query == "" {
+		return redactedURL
+	}
+
+	queryParts := strings.Split(query, "&")
+	for i, queryPart := range queryParts {
+		if queryPart == "" {
+			continue
+		}
+		key := queryPart
+		if equalSign := strings.Index(queryPart, "="); equalSign != -1 {
+			key = queryPart[:equalSign]
+		}
+		if key == "" {
+			queryParts[i] = "[REDACTED]"
+			continue
+		}
+		queryParts[i] = key + "=[REDACTED]"
+	}
+
+	return prefix + strings.Join(queryParts, "&") + fragment
+}
+
+func redactURLUserinfo(rawURL string) string {
+	authorityStart := strings.Index(rawURL, "://")
+	if authorityStart == -1 {
+		if !strings.HasPrefix(rawURL, "//") {
+			return rawURL
+		}
+		authorityStart = 2
+	} else {
+		authorityStart += len("://")
+	}
+
+	authorityEnd := len(rawURL)
+	for _, separator := range []string{"/", "?", "#"} {
+		if index := strings.Index(rawURL[authorityStart:], separator); index != -1 && authorityStart+index < authorityEnd {
+			authorityEnd = authorityStart + index
+		}
+	}
+
+	if atSign := strings.LastIndex(rawURL[authorityStart:authorityEnd], "@"); atSign != -1 {
+		return rawURL[:authorityStart] + "[REDACTED]@" + rawURL[authorityStart+atSign+1:]
+	}
+
+	return rawURL
 }
 
 func NewClientArgs(timeout int, baseUrl string) ClientArgs {

--- a/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/update_clientcertificatev2.go
+++ b/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/update_clientcertificatev2.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package syntheticsclientv2
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+func parseUpdateClientCertificateV2Response(response string) (*ClientCertificateV2Response, error) {
+	var updateClientCertificateV2 ClientCertificateV2Response
+	if response != "" {
+		err := json.Unmarshal([]byte(response), &updateClientCertificateV2)
+		if err != nil {
+			return nil, err
+		}
+		return &updateClientCertificateV2, nil
+	}
+	return &updateClientCertificateV2, nil
+}
+
+func (c Client) UpdateClientCertificateV2(id int, input *ClientCertificateV2UpdateInput) (*ClientCertificateV2Response, *RequestDetails, error) {
+	body, err := json.Marshal(input)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	details, err := c.makePublicAPICall("PUT", fmt.Sprintf("/certificates/%d", id), bytes.NewBuffer(body), nil)
+	if err != nil {
+		return nil, details, err
+	}
+
+	updateClientCertificateV2, err := parseUpdateClientCertificateV2Response(details.ResponseBody)
+	if err != nil {
+		return updateClientCertificateV2, details, err
+	}
+
+	return updateClientCertificateV2, details, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -175,7 +175,7 @@ github.com/oklog/run
 # github.com/splunk/syntheticsclient v1.0.3
 ## explicit; go 1.14
 github.com/splunk/syntheticsclient/syntheticsclient
-# github.com/splunk/syntheticsclient/v2 v2.4.0
+# github.com/splunk/syntheticsclient/v2 v2.6.0
 ## explicit; go 1.16
 github.com/splunk/syntheticsclient/v2/syntheticsclientv2
 # github.com/vmihailenco/msgpack v4.0.4+incompatible


### PR DESCRIPTION
## Summary

Fix Terraform apply/refresh failures for SSL tests when the SignalFX API returns a UUID string in `lastRunId`.

This PR supersedes #94 with a dependency-consistent implementation.

## Changes

- Upgrade `github.com/splunk/syntheticsclient/v2` from `v2.4.0` to the released [`v2.6.0`](https://github.com/splunk/syntheticsclient/releases/tag/v2.6.0).
- Vendor the complete released client module instead of manually modifying a vendored model.
- Model `last_run_id` as a computed string in both the SSL resource and data source.
- Preserve non-empty UUID values when flattening SSL responses into Terraform state.
- Update generated-facing resource and data-source documentation from Number to String.
- Add regression coverage that:
  - verifies both Terraform schemas use `TypeString`; and
  - unmarshals a UUID `lastRunId` through the released client model and confirms it reaches flattened state unchanged.

Upstream client fix: [splunk/syntheticsclient#46](https://github.com/splunk/syntheticsclient/pull/46)

Jira: [SYN-6805](https://splunk.atlassian.net/browse/SYN-6805)

## Validation

Passed locally:

```text
go test ./synthetics -run 'TestSslCheckV2LastRunIDSchemaUsesString|TestFlattenSslCheckV2ReadPreservesUUIDLastRunID|TestFlattenSslCheckV2ReadPreservesNullableServerNameAndCaCertificateID' -v
go test ./... -run '^$'
go vet ./...
go build .
go list -mod=vendor ./...
go generate ./...
git diff --check
```

The full runtime test suite could not be executed in the local sandbox because unrelated `httptest` tests are prohibited from binding localhost ports. GitHub CI will run in a normal runner environment.

## Compatibility

`last_run_id` is computed, but its Terraform value changes from Number to String to match the API's UUID representation.