### PR TITLE
Fix stale test_ids and dates in downtime configuration acceptance tests

### DIFF
--- a/synthetics/resource_browser_check_test.go
+++ b/synthetics/resource_browser_check_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestAccBrowserCheckBasic(t *testing.T) {
+	t.Skip("Rigor Classic (V1) has been deprecated; monitoring-api.rigor.com no longer resolves. Skipping until this V1 resource and its tests are removed.")
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,

--- a/synthetics/resource_downtime_configuration_v2_recurring_test.go
+++ b/synthetics/resource_downtime_configuration_v2_recurring_test.go
@@ -15,24 +15,42 @@
 package synthetics
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 // start_time must be in the future and no more than one year in the future
 // end_time must be after the start_time and no more than one year after the start_time
-// test_ids must be existing test_ids in the org
-const newRecurringDowntimeConfigurationV2Config = `
+// test_ids must be existing test_ids in the org, so a fixture port check is created
+// in the same config and its generated ID is referenced instead of a hardcoded value.
+func testAccRecurringDowntimeConfigurationV2Config(name, description, startTime, endTime, recurrenceEndDate string) string {
+	return fmt.Sprintf(`
+resource "synthetics_create_port_check_v2" "downtime_v2_recurring_fixture" {
+	provider = synthetics.synthetics
+  test {
+    active = true
+    frequency = 5
+    location_ids = ["aws-us-west-2"]
+    scheduling_strategy = "round_robin"
+    name = "%[1]s-fixture"
+    port = 8081
+    protocol = "tcp"
+    host = "www.splunk.com"
+  }
+}
+
 resource "synthetics_create_downtime_configuration_v2" "downtime_configuration_v2_foo_recurring" {
 	provider = synthetics.synthetics
   downtime_configuration {
-    name = "acceptance-downtime-configuration-recurring-terraform-test"
-    description = "The most awesome recurring downtime_configuration. Full of snakes."
+    name = "%[1]s"
+    description = "%[2]s"
     rule = "augment_data"
-    start_time = "2025-03-25T17:13:00.000Z"
-    end_time = "2025-03-25T18:13:00.000Z"
-    test_ids = [1523512]
+    start_time = "%[3]s"
+    end_time = "%[4]s"
+    test_ids = [tonumber(synthetics_create_port_check_v2.downtime_v2_recurring_fixture.id)]
     timezone = "America/New_York"
     recurrence {
       repeats {
@@ -40,32 +58,39 @@ resource "synthetics_create_downtime_configuration_v2" "downtime_configuration_v
       }
       end {
         type = "on"
-        value = "2025-04-25"
+        value = "%[5]s"
       }
     }
   }
 }
-`
+`, name, description, startTime, endTime, recurrenceEndDate)
+}
 
 func TestAccCreateRecurringDowntimeConfigurationV2(t *testing.T) {
+
+	name := fmt.Sprintf("acceptance-downtime-configuration-recurring-terraform-test-%d", time.Now().UnixNano())
+	description := "The most awesome recurring downtime_configuration. Full of snakes."
+	startTime := time.Now().Add(24 * time.Hour).Format("2006-01-02T15:04:05.000Z")
+	endTime := time.Now().Add(25 * time.Hour).Format("2006-01-02T15:04:05.000Z")
+	recurrenceEndDate := time.Now().Add(30 * 24 * time.Hour).Format("2006-01-02")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			// Create It
+			// Create the fixture test and the recurring downtime configuration referencing it.
 			{
-				Config: providerConfig + newRecurringDowntimeConfigurationV2Config,
+				Config: providerConfig + testAccRecurringDowntimeConfigurationV2Config(name, description, startTime, endTime, recurrenceEndDate),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("synthetics_create_downtime_configuration_v2.downtime_configuration_v2_foo_recurring", "downtime_configuration.0.description", "The most awesome recurring downtime_configuration. Full of snakes."),
+					resource.TestCheckResourceAttr("synthetics_create_downtime_configuration_v2.downtime_configuration_v2_foo_recurring", "downtime_configuration.0.description", description),
 					resource.TestCheckResourceAttr("synthetics_create_downtime_configuration_v2.downtime_configuration_v2_foo_recurring", "downtime_configuration.0.rule", "augment_data"),
-					resource.TestCheckResourceAttr("synthetics_create_downtime_configuration_v2.downtime_configuration_v2_foo_recurring", "downtime_configuration.0.name", "acceptance-downtime-configuration-recurring-terraform-test"),
-					resource.TestCheckResourceAttr("synthetics_create_downtime_configuration_v2.downtime_configuration_v2_foo_recurring", "downtime_configuration.0.start_time", "2025-03-25T17:13:00.000Z"),
-					resource.TestCheckResourceAttr("synthetics_create_downtime_configuration_v2.downtime_configuration_v2_foo_recurring", "downtime_configuration.0.end_time", "2025-03-25T18:13:00.000Z"),
+					resource.TestCheckResourceAttr("synthetics_create_downtime_configuration_v2.downtime_configuration_v2_foo_recurring", "downtime_configuration.0.name", name),
+					resource.TestCheckResourceAttr("synthetics_create_downtime_configuration_v2.downtime_configuration_v2_foo_recurring", "downtime_configuration.0.start_time", startTime),
+					resource.TestCheckResourceAttr("synthetics_create_downtime_configuration_v2.downtime_configuration_v2_foo_recurring", "downtime_configuration.0.end_time", endTime),
 					resource.TestCheckResourceAttr("synthetics_create_downtime_configuration_v2.downtime_configuration_v2_foo_recurring", "downtime_configuration.0.timezone", "America/New_York"),
 					resource.TestCheckResourceAttr("synthetics_create_downtime_configuration_v2.downtime_configuration_v2_foo_recurring", "downtime_configuration.0.recurrence.0.repeats.0.type", "daily"),
 					resource.TestCheckResourceAttr("synthetics_create_downtime_configuration_v2.downtime_configuration_v2_foo_recurring", "downtime_configuration.0.recurrence.0.end.0.type", "on"),
-					resource.TestCheckResourceAttr("synthetics_create_downtime_configuration_v2.downtime_configuration_v2_foo_recurring", "downtime_configuration.0.recurrence.0.end.0.value", "2025-04-25"),
+					resource.TestCheckResourceAttr("synthetics_create_downtime_configuration_v2.downtime_configuration_v2_foo_recurring", "downtime_configuration.0.recurrence.0.end.0.value", recurrenceEndDate),
 				),
 			},
 			{

--- a/synthetics/resource_downtime_configuration_v2_test.go
+++ b/synthetics/resource_downtime_configuration_v2_test.go
@@ -15,43 +15,67 @@
 package synthetics
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 // start_time must be in the future and no more than one year in the future
 // end_time must be after the start_time and no more than one year after the start_time
-// test_ids must be existing test_ids in the org
-const newDowntimeConfigurationV2Config = `
+// test_ids must be existing test_ids in the org, so a fixture port check is created
+// in the same config and its generated ID is referenced instead of a hardcoded value.
+func testAccDowntimeConfigurationV2Config(name, description, startTime, endTime string) string {
+	return fmt.Sprintf(`
+resource "synthetics_create_port_check_v2" "downtime_v2_fixture" {
+	provider = synthetics.synthetics
+  test {
+    active = true
+    frequency = 5
+    location_ids = ["aws-us-west-2"]
+    scheduling_strategy = "round_robin"
+    name = "%[1]s-fixture"
+    port = 8081
+    protocol = "tcp"
+    host = "www.splunk.com"
+  }
+}
+
 resource "synthetics_create_downtime_configuration_v2" "downtime_configuration_v2_foo" {
 	provider = synthetics.synthetics
   downtime_configuration {
-    name = "acceptance-downtime-configuration-terraform-test"
-    description = "The most awesome downtime_configuration. Full of snakes."
+    name = "%[1]s"
+    description = "%[2]s"
     rule = "augment_data"
-    start_time = "2025-07-01T17:13:00.000Z"
-    end_time = "2025-08-01T17:13:00.000Z"
-    test_ids = [1523512]
+    start_time = "%[3]s"
+    end_time = "%[4]s"
+    test_ids = [tonumber(synthetics_create_port_check_v2.downtime_v2_fixture.id)]
   }
 }
-`
+`, name, description, startTime, endTime)
+}
 
 func TestAccCreateDowntimeConfigurationV2(t *testing.T) {
+
+	name := fmt.Sprintf("acceptance-downtime-configuration-terraform-test-%d", time.Now().UnixNano())
+	description := "The most awesome downtime_configuration. Full of snakes."
+	startTime := time.Now().Add(24 * time.Hour).Format("2006-01-02T15:04:05.000Z")
+	endTime := time.Now().Add(48 * time.Hour).Format("2006-01-02T15:04:05.000Z")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			// Create It
+			// Create the fixture test and the downtime configuration referencing it.
 			{
-				Config: providerConfig + newDowntimeConfigurationV2Config,
+				Config: providerConfig + testAccDowntimeConfigurationV2Config(name, description, startTime, endTime),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("synthetics_create_downtime_configuration_v2.downtime_configuration_v2_foo", "downtime_configuration.0.description", "The most awesome downtime_configuration. Full of snakes."),
+					resource.TestCheckResourceAttr("synthetics_create_downtime_configuration_v2.downtime_configuration_v2_foo", "downtime_configuration.0.description", description),
 					resource.TestCheckResourceAttr("synthetics_create_downtime_configuration_v2.downtime_configuration_v2_foo", "downtime_configuration.0.rule", "augment_data"),
-					resource.TestCheckResourceAttr("synthetics_create_downtime_configuration_v2.downtime_configuration_v2_foo", "downtime_configuration.0.name", "acceptance-downtime-configuration-terraform-test"),
-					resource.TestCheckResourceAttr("synthetics_create_downtime_configuration_v2.downtime_configuration_v2_foo", "downtime_configuration.0.start_time", "2025-07-01T17:13:00.000Z"),
-					resource.TestCheckResourceAttr("synthetics_create_downtime_configuration_v2.downtime_configuration_v2_foo", "downtime_configuration.0.end_time", "2025-08-01T17:13:00.000Z"),
+					resource.TestCheckResourceAttr("synthetics_create_downtime_configuration_v2.downtime_configuration_v2_foo", "downtime_configuration.0.name", name),
+					resource.TestCheckResourceAttr("synthetics_create_downtime_configuration_v2.downtime_configuration_v2_foo", "downtime_configuration.0.start_time", startTime),
+					resource.TestCheckResourceAttr("synthetics_create_downtime_configuration_v2.downtime_configuration_v2_foo", "downtime_configuration.0.end_time", endTime),
 				),
 			},
 			{

--- a/synthetics/resource_http_check_test.go
+++ b/synthetics/resource_http_check_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestAccHttpCheckBasic(t *testing.T) {
+	t.Skip("Rigor Classic (V1) has been deprecated; monitoring-api.rigor.com no longer resolves. Skipping until this V1 resource and its tests are removed.")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },


### PR DESCRIPTION
## Why

`TestAccCreateDowntimeConfigurationV2` and `TestAccCreateRecurringDowntimeConfigurationV2` were failing with `404 Record not found` because both hardcoded `test_ids = [1523512]`, and that test no longer exists in the acceptance-test org (confirmed live: `GET /v2/synthetics/tests/1523512` → 404, while `GET /v2/synthetics/tests?limit=5` shows only IDs 7, 8, 9, 10, 12 currently exist). Both tests also hardcoded `start_time`/`end_time`/`recurrence.end.value` dates now in the past, violating the API's documented constraint that `start_time` must be in the future.

This isn't a new problem — `git log` shows the same pattern before: an earlier hardcoded ID (`932826`, with 2024 dates) went stale and was swapped for `1523512`/2025 dates in a prior commit, which has now also gone stale. Hardcoding a live test ID and calendar dates guarantees these tests break again on a schedule.

This PR also folds in a second, related fix (previously opened separately as #104, now closed and merged in here): `TestAccHttpCheckBasic` and `TestAccBrowserCheckBasic` exercise the deprecated Rigor Classic (V1) API via `monitoring-api.rigor.com`, which no longer resolves in DNS anywhere (confirmed against public resolvers `8.8.8.8`/`1.1.1.1`, not just this environment) — a permanent, unfixable-in-code failure now that Rigor Classic is deprecated. Per team decision, the V1 resources/tests will be removed later; in the meantime they're marked skipped instead of failing.

Root-caused and confirmed unrelated to any other in-flight change; both issues reproduce identically on `main`.

## What changed

- `TestAccCreateDowntimeConfigurationV2` / `TestAccCreateRecurringDowntimeConfigurationV2`:
  - Both tests now create a self-contained fixture resource (`synthetics_create_port_check_v2`) in the same Terraform config and reference its generated ID (`tonumber(synthetics_create_port_check_v2.<fixture>.id)`) for `test_ids`, instead of a hardcoded numeric literal.
  - `start_time`, `end_time`, and the recurring test's `recurrence.end.value` are now computed at run time via `time.Now().Add(...).Format(...)` instead of hardcoded literal dates.
  - Config strings switched from static `const` HCL to `fmt.Sprintf`-based builder functions (`testAccDowntimeConfigurationV2Config`, `testAccRecurringDowntimeConfigurationV2Config`), matching the pattern already used elsewhere in this test suite (e.g. `testAccTotpVariableV2Config`).
  - Resource/config names include `time.Now().UnixNano()` to avoid collisions across runs, matching the pattern in `resource_client_certificate_v2_test.go`.
  - Both tests now pass without depending on any pre-existing data in the org and won't drift out of validity with the calendar.
- `TestAccHttpCheckBasic` / `TestAccBrowserCheckBasic`:
  - Added `t.Skip(...)` explaining why (Rigor Classic V1 deprecated), so `go test` reports them as `SKIP` instead of permanently `FAIL`, until the V1 resources and their tests are removed.

## Validation

- `go build ./...`, `go vet ./...` — clean.
- `go test ./...` — full unit suite passes.
- Targeted acceptance run against a live Synthetics account: `TestAccCreateDowntimeConfigurationV2`, `TestAccCreateRecurringDowntimeConfigurationV2` — both **PASS**; `TestAccHttpCheckBasic`, `TestAccBrowserCheckBasic` — both **SKIP**.
- Full acceptance suite (`TF_ACC=1 go test ./synthetics -v -count=1 -timeout 30m`) on this rebased branch: **83 passed, 2 skipped, 0 failed**. No regressions.

### Pull request checklist

- [x] No breaking change
- [x] Build/vet/unit tests pass
- [x] Acceptance tests run — clean: 83 passed, 2 intentionally skipped, 0 failed


## Full acceptance test results

Full run of `TF_ACC=1 go test ./synthetics -v -count=1 -timeout 30m` on this rebased branch (`agent/fix-stale-downtime-config-test-fixtures`) against a live Synthetics account — **83 passed, 2 skipped, 0 failed**:

```
--- PASS: TestCaCertificateRequestDetailsRedactsSensitiveValues (0.00s)
--- PASS: TestClientCertificateV2DataSourceIsMetadataOnly (0.00s)
--- PASS: TestClientCertificatesV2DataSourceIsMetadataOnly (0.00s)
--- PASS: TestDataSourceExcludedFileTypesV2Read (0.00s)
--- PASS: TestAccDataSourceExcludedFileTypesV2 (4.26s)
--- PASS: TestProvider (0.00s)
--- PASS: TestProvider_impl (0.00s)
--- PASS: TestProviderContainsRecentV2ResourcesAndDataSources (0.00s)
--- PASS: TestAccCreateUpdateApiCheckV2 (5.73s)
--- PASS: TestBuildAPIRequestConfigurationIncludesCertificateID (0.00s)
--- PASS: TestFlattenAPIRequestConfigurationIncludesCertificateID (0.00s)
--- SKIP: TestAccBrowserCheckBasic (0.00s)
--- PASS: TestAccCreateUpdateBrowserCheckV2MaxWaitTime (19.99s)
--- PASS: TestAccCreateUpdateBrowserCheckV2 (9.13s)
--- PASS: TestBuildBrowserAdvancedSettingsIncludesCertificateIDs (0.00s)
--- PASS: TestBuildBrowserAdvancedSettingsClearsCertificateIDs (0.00s)
--- PASS: TestFlattenBrowserAdvancedSettingsIncludesCertificateIDs (0.00s)
--- PASS: TestAccCreateUpdateBrowserCheckV2WaitForNav (41.04s)
--- PASS: TestAccCreateUpdateCaCertificateV2 (5.71s)
--- PASS: TestClientCertificateV2SchemaMarksSecretFieldsSensitive (0.00s)
--- PASS: TestValidateClientCertificateName (0.00s)
--- PASS: TestFlattenClientCertificateV2PreservesStateSecretsWhenAPIIsRedacted (0.00s)
--- PASS: TestClientCertificatePasswordRemovalWithUnchangedPrivateKeyIsRejected (0.00s)
--- PASS: TestClientCertificatePasswordOmittedWithReplacedPrivateKeyIsAllowed (0.00s)
--- PASS: TestAccCreateUpdateClientCertificateV2 (5.95s)
--- PASS: TestAccClientCertificateV2Attachments (6.09s)
--- PASS: TestAccCreateRecurringDowntimeConfigurationV2 (4.94s)
--- PASS: TestAccCreateDowntimeConfigurationV2 (4.92s)
--- SKIP: TestAccHttpCheckBasic (0.00s)
--- PASS: TestAccCreateUpdateHttpCheckV2 (6.70s)
--- PASS: TestBuildHttpV2DataIncludesCertificateID (0.00s)
--- PASS: TestFlattenHttpV2ReadIncludesCertificateID (0.00s)
--- PASS: TestFlattenHttpV2ReadResetsClearedCertificateIDInState (0.00s)
--- PASS: TestBuildHttpV2UpdateClearsRemovedCertificateID (0.00s)
--- PASS: TestAccCreateLocationV2 (3.95s)
--- PASS: TestAccCreateUpdatePortCheckV2 (5.27s)
--- PASS: TestAccCreateUpdateSslCheckV2 (5.25s)
--- PASS: TestSslCheckV2AcceptanceConfigsOmitUnsupportedCertificateValidations (0.00s)
--- PASS: TestSslCheckV2LastRunIDSchemaUsesString (0.00s)
--- PASS: TestSslCheckV2ValidationSchemaExposesOnlyControllerAllowedFields (0.00s)
--- PASS: TestAccCreateTotpVariableV2 (5.27s)
--- PASS: TestAccBrowserCheckV2WithTotpVariableReference (4.62s)
--- PASS: TestAccTotpVariableV2DataSources (4.73s)
--- PASS: TestAccCreateUpdateVariableV2 (5.52s)
--- PASS: TestBuildSelectorsFromStep_multipleSelectors (0.00s)
--- PASS: TestBuildSelectorsFromStep_legacyFields (0.00s)
--- PASS: TestDropStaleStepSelectors_legacyUpdateWins (0.00s)
--- PASS: TestBuildSelectorsFromStep_prefersSelectorsList (0.00s)
--- PASS: TestFlattenStepsData_singleSelectorUsesSelectorsBlock (0.00s)
--- PASS: TestStepSelectorInputsEquivalent_legacyAndSelectorsBlock (0.00s)
--- PASS: TestMigratingFromLegacyToSelectors_afterApplyNotMigration (0.00s)
--- PASS: TestFlattenStepsData_multipleSelectorsExposed (0.00s)
--- PASS: TestBuildSelectorsFromStep_tooManySelectors (0.00s)
--- PASS: TestBuildExcludedFilesV2Data (0.00s)
--- PASS: TestBuildExcludedFilesV2DataNilAndEmpty (0.00s)
--- PASS: TestBuildExcludedFilesV2DataValidation (0.00s)
--- PASS: TestFlattenExcludedFilesV2Data (0.00s)
--- PASS: TestBuildAdvancedSettingsDataSendsEmptyExcludedFiles (0.00s)
--- PASS: TestBrowserV2AdvancedSettingsSensitiveFields (0.00s)
--- PASS: TestBuildSslCheckV2DataSetsNullableFieldsValidationsAndCustomProperties (0.00s)
--- PASS: TestBuildValidationsDataToleratesMissingGenericValidationFields (0.00s)
--- PASS: TestBuildSslCheckV2UpdateDataSendsExplicitNullsForAbsentNullableFields (0.00s)
--- PASS: TestFlattenSslCheckV2ReadPreservesNullableServerNameAndCaCertificateID (0.00s)
--- PASS: TestFlattenSslCheckV2ReadPreservesUUIDLastRunID (0.00s)
--- PASS: TestBuildCaCertificateV2DataRequiresContent (0.00s)
--- PASS: TestCaCertificateV2ContentSchemaIsRequiredAndSensitive (0.00s)
--- PASS: TestBuildCaCertificateV2UpdateDataDoesNotSendRedactedContent (0.00s)
--- PASS: TestFlattenCaCertificateV2ReadPreservesExistingStateContent (0.00s)
--- PASS: TestBuildHttpV2DataUsesNullPortWhenOmitted (0.00s)
--- PASS: TestBuildHttpV2DataPreservesExplicitZeroPort (0.00s)
--- PASS: TestBuildHttpV2DataPreservesConfiguredPortAndCertificate (0.00s)
--- PASS: TestBuildHttpV2DataIgnoresStaleRawPlanPortWhenCurrentConfigOmitsPort (0.00s)
--- PASS: TestFlattenHttpV2ReadPortSemantics (0.00s)
--- PASS: TestFlattenHttpV2DataIncludesPortForDataSource (0.00s)
--- PASS: TestHttpV2PortSchemas (0.00s)
--- PASS: TestTotpVariableV2SecretSchemaIsRequiredAndSensitive (0.00s)
--- PASS: TestTotpVariableV2Defaults (0.00s)
--- PASS: TestTotpVariableDataSourcesDoNotExposeSecret (0.00s)
--- PASS: TestBuildTotpVariableV2DataRequiresSecret (0.00s)
--- PASS: TestBuildTotpVariableV2Data (0.00s)
--- PASS: TestBuildTotpVariableV2UpdateDataDoesNotSendRedactedSecret (0.00s)
--- PASS: TestBuildTotpVariableV2UpdateDataSendsChangedSecret (0.00s)
--- PASS: TestFlattenTotpVariableV2ReadPreservesExistingStateSecret (0.00s)
--- PASS: TestFlattenTotpVariableV2MetadataDoesNotSetSecret (0.00s)
--- PASS: TestBuildBrowserV2DataAcceptsTotpStepReference (0.00s)
PASS
ok  	github.com/splunk/terraform-provider-synthetics/synthetics	149.385s
```
