### PR TITLE
Skip deprecated Rigor Classic (V1) acceptance tests

### DIFF
--- a/synthetics/resource_browser_check_test.go
+++ b/synthetics/resource_browser_check_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestAccBrowserCheckBasic(t *testing.T) {
+	t.Skip("Rigor Classic (V1) has been deprecated; monitoring-api.rigor.com no longer resolves. Skipping until this V1 resource and its tests are removed.")
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,

--- a/synthetics/resource_http_check_test.go
+++ b/synthetics/resource_http_check_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestAccHttpCheckBasic(t *testing.T) {
+	t.Skip("Rigor Classic (V1) has been deprecated; monitoring-api.rigor.com no longer resolves. Skipping until this V1 resource and its tests are removed.")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },


### PR DESCRIPTION
## Why

`TestAccHttpCheckBasic` and `TestAccBrowserCheckBasic` exercise the legacy Rigor Classic (V1) API by configuring the provider with `product = "rigor"` (`rigorConfig`, [provider_test.go:47](synthetics/provider_test.go#L47)). The vendored V1 client hardcodes its base URL to `https://monitoring-api.rigor.com` ([vendor/github.com/splunk/syntheticsclient/syntheticsclient/synthetics.go:129](vendor/github.com/splunk/syntheticsclient/syntheticsclient/synthetics.go#L129)).

That hostname has been decommissioned — confirmed it doesn't resolve against public DNS resolvers (`8.8.8.8`, `1.1.1.1`), not just this environment, while sibling hosts like `www.rigor.com` resolve fine. Both tests fail every run with `dial tcp: lookup monitoring-api.rigor.com: no such host`, which is a permanent, unfixable-in-code failure now that Rigor Classic is deprecated.

Per team decision, the V1 resources/tests will be removed later; in the meantime these two tests shouldn't keep showing up as acceptance-suite failures.

## What changed

- Added `t.Skip(...)` at the top of `TestAccHttpCheckBasic` and `TestAccBrowserCheckBasic`, explaining why, so `go test` reports them as `SKIP` instead of `FAIL`.
- No other code changed — this is intentionally minimal since the V1 resources themselves are slated for removal in a future change.

## Validation

- `go build ./...`, `go vet ./...` — clean.
- `go test ./...` — unit suite passes.
- `TF_ACC=1 go test ./synthetics -run 'TestAccHttpCheckBasic|TestAccBrowserCheckBasic' -v`: both **SKIP** with the explanatory message.
- Full acceptance suite (`TF_ACC=1 go test ./synthetics -v -count=1 -timeout 30m`) on this branch (based on `main`, before the unrelated downtime-configuration fixture fix in #103 lands): 81 passed, 2 skipped (the two Rigor tests), 2 failed — the 2 failures are `TestAccCreateDowntimeConfigurationV2`/`TestAccCreateRecurringDowntimeConfigurationV2`, which are the pre-existing stale-test-ID issue already fixed separately in #103. No new regressions from this change.

### Pull request checklist

- [x] No breaking change
- [x] Build/vet/unit tests pass
- [x] Acceptance tests run — target tests now skip cleanly instead of failing