### PR TITLE
Add gated integration test workflow for PRs

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -307,3 +307,55 @@ jobs:
               issue_number: Number(process.env.PR_NUMBER),
               body: `### Integration Test: ${conclusion === 'success' ? '✅ Passed' : '❌ Failed'}\n\n[View run](${runUrl})\n\n${table}`,
             });
+
+  # Ungated, and scheduled regardless of how integration-test ended. Needed
+  # because environment-approval rejection or timeout fails the
+  # integration-test job before any of its own steps run — including its
+  # "Report check run result" step — which would otherwise leave the check
+  # `resolve` created stuck at queued/in_progress until GitHub marks it stale
+  # after 14 days, hiding the rejection/timeout from the required check.
+  finalize-on-incomplete:
+    name: finalize-on-incomplete
+    needs: [resolve, integration-test]
+    if: always() && needs.resolve.outputs.found == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Ensure the check run reaches a terminal state
+        uses: actions/github-script@v7
+        env:
+          PR_SHA: ${{ needs.resolve.outputs.sha }}
+          PR_NUMBER: ${{ needs.resolve.outputs.number }}
+        with:
+          script: |
+            const checks = await github.rest.checks.listForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: process.env.PR_SHA,
+              check_name: 'integration-test',
+            });
+            const check = checks.data.check_runs[0];
+            // If integration-test ran far enough to reach its own "Report check run
+            // result" step, the check is already completed and there's nothing to do.
+            if (!check || check.status === 'completed') return;
+
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.checks.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              check_run_id: check.id,
+              status: 'completed',
+              conclusion: 'failure',
+              details_url: runUrl,
+              output: {
+                title: 'Integration test did not complete',
+                summary: 'The integration-test job did not run to completion — the environment approval was likely rejected or timed out before the job started.',
+              },
+            });
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number(process.env.PR_NUMBER),
+              body: `### Integration Test: ❌ Failed\n\nThe integration-test job did not run to completion — the environment approval was likely rejected or timed out before the job started. [View run](${runUrl})`,
+            });

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -13,6 +13,11 @@ on:
   workflow_run:
     workflows: ["PR Metadata"]
     types: [completed]
+  # TEMPORARY — validates the job logic on this PR, since workflow_run only
+  # fires for workflows already on the default branch and this file isn't
+  # there yet. Remove this pull_request trigger before merging.
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
@@ -21,13 +26,13 @@ permissions:
   checks: write
 
 concurrency:
-  group: integration-test-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  group: integration-test-${{ github.event_name == 'workflow_run' && format('{0}-{1}', github.event.workflow_run.head_repository.full_name, github.event.workflow_run.head_branch) || github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   integration-test:
     name: integration-test
-    if: github.event.workflow_run.conclusion == 'success'
+    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     timeout-minutes: 40
     environment: integration-test   # gate: waits for reviewer approval here
@@ -35,6 +40,7 @@ jobs:
     steps:
       - name: Download PR metadata
         id: download
+        if: github.event_name == 'workflow_run'
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
@@ -46,6 +52,15 @@ jobs:
       - name: Read PR metadata
         id: pr
         run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # TEMPORARY branch for direct pull_request validation — remove with the trigger above.
+            {
+              echo "found=true"
+              echo "number=${{ github.event.pull_request.number }}"
+              echo "sha=${{ github.event.pull_request.head.sha }}"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if [ "${{ steps.download.outcome }}" != "success" ] || [ ! -s pr-metadata/pr-number ]; then
             # PR Metadata's record-pr job was skipped (e.g. draft PR) and produced no
             # artifact — nothing to test, exit without creating a check or comment.

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -13,11 +13,6 @@ on:
   workflow_run:
     workflows: ["PR Metadata"]
     types: [completed]
-  # TEMPORARY — validates the job logic on this PR, since workflow_run only
-  # fires for workflows already on the default branch and this file isn't
-  # there yet. Remove this pull_request trigger before merging.
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
@@ -26,13 +21,13 @@ permissions:
   checks: write
 
 concurrency:
-  group: integration-test-${{ github.event_name == 'workflow_run' && format('{0}-{1}', github.event.workflow_run.head_repository.full_name, github.event.workflow_run.head_branch) || github.event.pull_request.number }}
+  group: integration-test-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 jobs:
   integration-test:
     name: integration-test
-    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 40
     environment: integration-test   # gate: waits for reviewer approval here
@@ -40,7 +35,6 @@ jobs:
     steps:
       - name: Download PR metadata
         id: download
-        if: github.event_name == 'workflow_run'
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
@@ -52,15 +46,6 @@ jobs:
       - name: Read PR metadata
         id: pr
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            # TEMPORARY branch for direct pull_request validation — remove with the trigger above.
-            {
-              echo "found=true"
-              echo "number=${{ github.event.pull_request.number }}"
-              echo "sha=${{ github.event.pull_request.head.sha }}"
-            } >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
           if [ "${{ steps.download.outcome }}" != "success" ] || [ ! -s pr-metadata/pr-number ]; then
             # PR Metadata's record-pr job was skipped (e.g. draft PR) and produced no
             # artifact — nothing to test, exit without creating a check or comment.

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -25,12 +25,21 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  integration-test:
-    name: integration-test
+  # Ungated on purpose: downloads and validates the pr-metadata artifact
+  # immediately, before any approval wait. An environment approval can take
+  # up to 30 days (GitHub's own timeout), which would otherwise force the
+  # artifact retention window to also cover the entire approval SLA. Resolving
+  # here means only this job's (short) runtime needs the artifact to still
+  # exist, not however long a reviewer takes to click approve.
+  resolve:
+    name: resolve
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 40
-    environment: integration-test   # gate: waits for reviewer approval here
+    timeout-minutes: 5
+    outputs:
+      found: ${{ steps.pr.outputs.found }}
+      number: ${{ steps.pr.outputs.number }}
+      sha: ${{ steps.pr.outputs.sha }}
 
     steps:
       - name: Download PR metadata
@@ -83,23 +92,59 @@ jobs:
               return;
             }
 
-            // Independently resolve which PR is open at that trusted SHA via the API,
-            // rather than trusting the artifact's pr-number — this is what prevents a
-            // tampered artifact from redirecting privileged testing/comments/checks to an
-            // unrelated PR.
-            const associated = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: trustedSha,
-            });
-            const matchingPr = associated.data.find(p => String(p.number) === rawNumber);
-            if (!matchingPr) {
-              core.setFailed(`No open PR #${rawNumber} found associated with commit ${trustedSha} via the GitHub API — refusing to trust the pr-metadata artifact.`);
+            // Fetch the PR the artifact claims by number, then verify every field that
+            // matters against values GitHub itself attached to this trusted workflow_run
+            // event — never trust the artifact's number on its own.
+            //
+            // Deliberately not using listPullRequestsAssociatedWithCommit or the
+            // workflow_run payload's own `pull_requests` field: (a) the commit-associated
+            // lookup can return multiple open/merged PRs for the same commit (e.g. a
+            // commit shared via cherry-pick or a stacked branch), letting a forged
+            // artifact redirect handling to an unrelated but-also-matching PR; and (b)
+            // workflow_run.pull_requests is documented to come back empty for PRs from
+            // forked repositories, which is precisely the case this workflow exists to
+            // support. Instead: fetch the claimed PR by number directly, then require
+            // every trust-relevant field to match values GitHub attached to this event.
+            let pr;
+            try {
+              const resp = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: Number(rawNumber),
+              });
+              pr = resp.data;
+            } catch (e) {
+              core.setFailed(`Could not fetch PR #${rawNumber} via the API — refusing to trust the pr-metadata artifact: ${e.message}`);
+              return;
+            }
+
+            const headRepo = context.payload.workflow_run.head_repository;
+            const baseRepo = context.payload.workflow_run.repository;
+            const headBranch = context.payload.workflow_run.head_branch;
+
+            if (pr.state !== 'open') {
+              core.setFailed(`PR #${rawNumber} is not open (state: ${pr.state}) — refusing to trust the pr-metadata artifact.`);
+              return;
+            }
+            if (pr.head.sha !== trustedSha) {
+              core.setFailed(`PR #${rawNumber}'s current head sha (${pr.head.sha}) does not match the trusted workflow_run head_sha (${trustedSha}) — PR head moved or artifact is stale/forged.`);
+              return;
+            }
+            if (!pr.head.repo || pr.head.repo.full_name !== headRepo.full_name) {
+              core.setFailed(`PR #${rawNumber}'s head repo (${pr.head.repo && pr.head.repo.full_name}) does not match the trusted workflow_run head_repository (${headRepo.full_name}) — refusing to trust the pr-metadata artifact.`);
+              return;
+            }
+            if (pr.head.ref !== headBranch) {
+              core.setFailed(`PR #${rawNumber}'s head branch (${pr.head.ref}) does not match the trusted workflow_run head_branch (${headBranch}) — refusing to trust the pr-metadata artifact.`);
+              return;
+            }
+            if (pr.base.repo.full_name !== baseRepo.full_name) {
+              core.setFailed(`PR #${rawNumber}'s base repo (${pr.base.repo.full_name}) is not this repository — refusing to trust the pr-metadata artifact.`);
               return;
             }
 
             core.setOutput('found', 'true');
-            core.setOutput('number', rawNumber);
+            core.setOutput('number', String(pr.number));
             core.setOutput('sha', trustedSha);
 
       - name: Create pending check run
@@ -114,21 +159,50 @@ jobs:
               repo: context.repo.repo,
               name: 'integration-test',
               head_sha: process.env.PR_SHA,
-              status: 'in_progress',
+              status: 'queued',
               details_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             });
 
+  integration-test:
+    name: integration-test
+    needs: resolve
+    if: needs.resolve.outputs.found == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    environment: integration-test   # gate: waits for reviewer approval here
+
+    steps:
+      - name: Mark check run in progress
+        uses: actions/github-script@v7
+        env:
+          PR_SHA: ${{ needs.resolve.outputs.sha }}
+        with:
+          script: |
+            const checks = await github.rest.checks.listForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: process.env.PR_SHA,
+              check_name: 'integration-test',
+            });
+            const check = checks.data.check_runs[0];
+            if (check) {
+              await github.rest.checks.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                check_run_id: check.id,
+                status: 'in_progress',
+              });
+            }
+
       - name: Checkout PR head
-        if: steps.pr.outputs.found == 'true'
         uses: actions/checkout@v4
         with:
-          ref: refs/pull/${{ steps.pr.outputs.number }}/head
+          ref: refs/pull/${{ needs.resolve.outputs.number }}/head
           persist-credentials: false
 
       - name: Verify checked-out SHA matches recorded PR head
-        if: steps.pr.outputs.found == 'true'
         env:
-          PR_SHA: ${{ steps.pr.outputs.sha }}
+          PR_SHA: ${{ needs.resolve.outputs.sha }}
         run: |
           actual="$(git rev-parse HEAD)"
           if [ "$actual" != "$PR_SHA" ]; then
@@ -137,20 +211,17 @@ jobs:
           fi
 
       - name: Setup Go
-        if: steps.pr.outputs.found == 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true
 
       - name: Setup Terraform
-        if: steps.pr.outputs.found == 'true'
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
 
       - name: Run acceptance tests against live endpoint
-        if: steps.pr.outputs.found == 'true'
         env:
           TF_VAR_observability_token: ${{ secrets.TF_VAR_OBSERVABILITY_TOKEN }}
           TF_VAR_realm: ${{ secrets.TF_VAR_REALM }}
@@ -158,12 +229,12 @@ jobs:
         run: make testacc
 
       - name: Report check run result
-        if: always() && steps.pr.outputs.found == 'true'
+        if: always()
         uses: actions/github-script@v7
         env:
           JOB_STATUS: ${{ job.status }}
-          PR_SHA: ${{ steps.pr.outputs.sha }}
-          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PR_SHA: ${{ needs.resolve.outputs.sha }}
+          PR_NUMBER: ${{ needs.resolve.outputs.number }}
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -13,6 +13,11 @@ on:
   workflow_run:
     workflows: ["PR Metadata"]
     types: [completed]
+  # TEMPORARY — validates the job logic on this PR, since workflow_run only
+  # fires for workflows already on the default branch and this file isn't
+  # there yet. Remove this pull_request trigger before merging.
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
@@ -21,13 +26,13 @@ permissions:
   checks: write
 
 concurrency:
-  group: integration-test-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  group: integration-test-${{ github.event_name == 'workflow_run' && format('{0}-{1}', github.event.workflow_run.head_repository.full_name, github.event.workflow_run.head_branch) || github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   integration-test:
     name: integration-test
-    if: github.event.workflow_run.conclusion == 'success'
+    if: (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') || (github.event_name == 'pull_request' && github.event.pull_request.draft == false)
     runs-on: ubuntu-latest
     timeout-minutes: 40
     environment: integration-test   # gate: waits for reviewer approval here
@@ -35,6 +40,7 @@ jobs:
     steps:
       - name: Download PR metadata
         id: download
+        if: github.event_name == 'workflow_run'
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
@@ -46,6 +52,15 @@ jobs:
       - name: Read PR metadata
         id: pr
         run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # TEMPORARY branch for direct pull_request validation — remove with the trigger above.
+            {
+              echo "found=true"
+              echo "number=${{ github.event.pull_request.number }}"
+              echo "sha=${{ github.event.pull_request.head.sha }}"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if [ "${{ steps.download.outcome }}" != "success" ] || [ ! -s pr-metadata/pr-number ]; then
             # PR Metadata's record-pr job was skipped (e.g. draft PR) and produced no
             # artifact — nothing to test, exit without creating a check or comment.
@@ -114,9 +129,47 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const fs = require('fs');
             const status = '${{ job.status }}';
             const conclusion = status === 'success' ? 'success' : 'failure';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            // testacc.jsonl already has X-Sf-Token lines stripped by GNUmakefile's
+            // testacc target (sed '/X-Sf-Token/d') before it ever reaches this file.
+            let table = '_No test output was captured (job likely failed before tests started)._';
+            if (fs.existsSync('testacc.jsonl')) {
+              const lines = fs.readFileSync('testacc.jsonl', 'utf8').split('\n');
+              const results = [];
+              let buildFailed = false;
+              for (const line of lines) {
+                if (!line) continue;
+                let event;
+                try {
+                  event = JSON.parse(line);
+                } catch (e) {
+                  continue;
+                }
+                if (event.Action === 'build-fail') buildFailed = true;
+                if (event.Test && (event.Action === 'pass' || event.Action === 'fail' || event.Action === 'skip')) {
+                  results.push(event);
+                }
+              }
+              results.sort((a, b) => a.Test.localeCompare(b.Test));
+
+              if (buildFailed) {
+                table = '⚠️ Build failed before any tests ran — see the job log for compiler errors.';
+              } else if (results.length === 0) {
+                table = '⚠️ No test results were produced — see the job log for details.';
+              } else {
+                const passed = results.filter(r => r.Action === 'pass').length;
+                const failed = results.filter(r => r.Action === 'fail').length;
+                const skipped = results.filter(r => r.Action === 'skip').length;
+                const icon = r => r.Action === 'pass' ? '✅ Pass' : r.Action === 'skip' ? '⚠️ Skip' : '❌ Fail';
+                const rows = results.map(r => `| ${r.Test} | ${icon(r)} | ${r.Elapsed ?? 0} |`).join('\n');
+                table = `**Total:** ${results.length} | **Passed:** ${passed} | **Failed:** ${failed} | **Skipped:** ${skipped}\n\n` +
+                  `| Test | Result | Duration (s) |\n|---|---|---|\n${rows}`;
+              }
+            }
 
             const checks = await github.rest.checks.listForRef({
               owner: context.repo.owner,
@@ -140,5 +193,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: ${{ steps.pr.outputs.number }},
-              body: `### Integration Test: ${conclusion === 'success' ? '✅ Passed' : '❌ Failed'}\n\n[View run](${runUrl})`,
+              body: `### Integration Test: ${conclusion === 'success' ? '✅ Passed' : '❌ Failed'}\n\n[View run](${runUrl})\n\n${table}`,
             });

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,58 @@
+name: Integration Test
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: integration-test-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  integration-test:
+    name: integration-test
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    environment: integration-test   # gate: waits for reviewer approval here
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+
+      - name: Run acceptance tests against live endpoint
+        env:
+          TF_VAR_observability_token: ${{ secrets.TF_VAR_OBSERVABILITY_TOKEN }}
+          TF_VAR_realm: ${{ secrets.TF_VAR_REALM }}
+          TF_VAR_rigor_token: ${{ secrets.TF_VAR_RIGOR_TOKEN }}
+        run: make testacc
+
+      - name: Post result to PR
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const status = '${{ job.status }}';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `### Integration Test: ${status === 'success' ? '✅ Passed' : '❌ Failed'}\n\n[View run](${runUrl})`,
+            });

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -335,9 +335,16 @@ jobs:
               check_name: 'integration-test',
             });
             const check = checks.data.check_runs[0];
-            // If integration-test ran far enough to reach its own "Report check run
-            // result" step, the check is already completed and there's nothing to do.
-            if (!check || check.status === 'completed') return;
+            // integration-test's own "Report check run result" step only ever sets
+            // conclusion 'success' or 'failure' — treat those, and only those, as
+            // already finalized. A queued/in_progress check left waiting on approval
+            // for more than 14 days is auto-completed by GitHub with conclusion
+            // 'stale' (see https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-checks),
+            // which happens well before the up-to-30-day approval timeout elapses —
+            // so status === 'completed' alone is not a safe "nothing to do" signal.
+            const reportedConclusions = ['success', 'failure'];
+            if (!check) return;
+            if (check.status === 'completed' && reportedConclusions.includes(check.conclusion)) return;
 
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             await github.rest.checks.update({

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -35,7 +35,6 @@ jobs:
     steps:
       - name: Download PR metadata
         id: download
-        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: pr-metadata
@@ -43,31 +42,78 @@ jobs:
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
 
-      - name: Read PR metadata
+      - name: Read and validate PR metadata
         id: pr
-        run: |
-          if [ "${{ steps.download.outcome }}" != "success" ] || [ ! -s pr-metadata/pr-number ]; then
-            # PR Metadata's record-pr job was skipped (e.g. draft PR) and produced no
-            # artifact — nothing to test, exit without creating a check or comment.
-            echo "found=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          {
-            echo "found=true"
-            echo "number=$(cat pr-metadata/pr-number)"
-            echo "sha=$(cat pr-metadata/pr-sha)"
-          } >> "$GITHUB_OUTPUT"
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            // pr-metadata.yml is a pull_request-triggered workflow, so its *file* can be
+            // rewritten by a fork PR to upload arbitrary pr-number/pr-sha content — never
+            // trust the artifact as-is. Enforce strict formats and cross-check against
+            // fields GitHub itself attaches to this trusted workflow_run event, which a
+            // rewritten pr-metadata.yml cannot forge.
+            //
+            // The job-level guard above (conclusion == 'success') already means a draft
+            // PR (whose record-pr job is skipped, reporting conclusion 'skipped') never
+            // reaches this job at all — verified empirically against a real draft PR. So
+            // getting here with a missing or malformed artifact is always an anomaly, not
+            // a legitimate "nothing to test" case: fail loudly rather than silently
+            // exiting success with no check or comment.
+            const rawNumber = fs.readFileSync('pr-metadata/pr-number', 'utf8').trim();
+            const rawSha = fs.readFileSync('pr-metadata/pr-sha', 'utf8').trim();
+
+            if (!/^[0-9]+$/.test(rawNumber)) {
+              core.setFailed(`pr-metadata artifact has malformed pr-number: ${JSON.stringify(rawNumber)}`);
+              return;
+            }
+            if (!/^[0-9a-f]{40}$/.test(rawSha)) {
+              core.setFailed(`pr-metadata artifact has malformed pr-sha: ${JSON.stringify(rawSha)}`);
+              return;
+            }
+
+            // github.event.workflow_run.head_sha is the commit that triggered the
+            // pr-metadata.yml run itself — a value GitHub computes and attaches to the
+            // workflow_run event independently of anything pr-metadata.yml's script did.
+            // Trust this, not the artifact's own pr-sha file.
+            const trustedSha = context.payload.workflow_run.head_sha;
+            if (rawSha !== trustedSha) {
+              core.setFailed(`pr-metadata artifact sha (${rawSha}) does not match the workflow_run's own head_sha (${trustedSha}) — refusing to trust a forged or stale artifact.`);
+              return;
+            }
+
+            // Independently resolve which PR is open at that trusted SHA via the API,
+            // rather than trusting the artifact's pr-number — this is what prevents a
+            // tampered artifact from redirecting privileged testing/comments/checks to an
+            // unrelated PR.
+            const associated = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: trustedSha,
+            });
+            const matchingPr = associated.data.find(p => String(p.number) === rawNumber);
+            if (!matchingPr) {
+              core.setFailed(`No open PR #${rawNumber} found associated with commit ${trustedSha} via the GitHub API — refusing to trust the pr-metadata artifact.`);
+              return;
+            }
+
+            core.setOutput('found', 'true');
+            core.setOutput('number', rawNumber);
+            core.setOutput('sha', trustedSha);
 
       - name: Create pending check run
         if: steps.pr.outputs.found == 'true'
         uses: actions/github-script@v7
+        env:
+          PR_SHA: ${{ steps.pr.outputs.sha }}
         with:
           script: |
             await github.rest.checks.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               name: 'integration-test',
-              head_sha: '${{ steps.pr.outputs.sha }}',
+              head_sha: process.env.PR_SHA,
               status: 'in_progress',
               details_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
             });
@@ -77,14 +123,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ steps.pr.outputs.number }}/head
+          persist-credentials: false
 
       - name: Verify checked-out SHA matches recorded PR head
         if: steps.pr.outputs.found == 'true'
+        env:
+          PR_SHA: ${{ steps.pr.outputs.sha }}
         run: |
           actual="$(git rev-parse HEAD)"
-          expected="${{ steps.pr.outputs.sha }}"
-          if [ "$actual" != "$expected" ]; then
-            echo "Checked-out SHA ($actual) does not match PR metadata ($expected) — PR head moved since pr-metadata ran, refusing to run privileged tests against a stale checkout." >&2
+          if [ "$actual" != "$PR_SHA" ]; then
+            echo "Checked-out SHA ($actual) does not match PR metadata ($PR_SHA) — PR head moved since pr-metadata ran, refusing to run privileged tests against a stale checkout." >&2
             exit 1
           fi
 
@@ -112,10 +160,14 @@ jobs:
       - name: Report check run result
         if: always() && steps.pr.outputs.found == 'true'
         uses: actions/github-script@v7
+        env:
+          JOB_STATUS: ${{ job.status }}
+          PR_SHA: ${{ steps.pr.outputs.sha }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         with:
           script: |
             const fs = require('fs');
-            const status = '${{ job.status }}';
+            const status = process.env.JOB_STATUS;
             const conclusion = status === 'success' ? 'success' : 'failure';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
 
@@ -163,7 +215,7 @@ jobs:
             const checks = await github.rest.checks.listForRef({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              ref: '${{ steps.pr.outputs.sha }}',
+              ref: process.env.PR_SHA,
               check_name: 'integration-test',
             });
             const check = checks.data.check_runs[0];
@@ -181,6 +233,6 @@ jobs:
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: ${{ steps.pr.outputs.number }},
+              issue_number: Number(process.env.PR_NUMBER),
               body: `### Integration Test: ${conclusion === 'success' ? '✅ Passed' : '❌ Failed'}\n\n[View run](${runUrl})\n\n${table}`,
             });

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -135,7 +135,11 @@ jobs:
                   continue;
                 }
                 if (event.Action === 'build-fail') buildFailed = true;
-                if (event.Test && (event.Action === 'pass' || event.Action === 'fail' || event.Action === 'skip')) {
+                // Only live acceptance tests (TestAcc* — the convention every
+                // resource.Test/ParallelTest caller in this repo follows) show up
+                // here; unit tests still run and still gate the job on failure,
+                // they're just not what this table is reporting on.
+                if (event.Test && event.Test.startsWith('TestAcc') && (event.Action === 'pass' || event.Action === 'fail' || event.Action === 'skip')) {
                   results.push(event);
                 }
               }
@@ -144,14 +148,14 @@ jobs:
               if (buildFailed) {
                 table = '⚠️ Build failed before any tests ran — see the job log for compiler errors.';
               } else if (results.length === 0) {
-                table = '⚠️ No test results were produced — see the job log for details.';
+                table = '⚠️ No acceptance test (TestAcc*) results were produced — see the job log for details.';
               } else {
                 const passed = results.filter(r => r.Action === 'pass').length;
                 const failed = results.filter(r => r.Action === 'fail').length;
                 const skipped = results.filter(r => r.Action === 'skip').length;
                 const icon = r => r.Action === 'pass' ? '✅ Pass' : r.Action === 'skip' ? '⚠️ Skip' : '❌ Fail';
                 const rows = results.map(r => `| ${r.Test} | ${icon(r)} | ${r.Elapsed ?? 0} |`).join('\n');
-                table = `**Total:** ${results.length} | **Passed:** ${passed} | **Failed:** ${failed} | **Skipped:** ${skipped}\n\n` +
+                table = `**Live acceptance tests — Total:** ${results.length} | **Passed:** ${passed} | **Failed:** ${failed} | **Skipped:** ${skipped}\n\n` +
                   `| Test | Result | Duration (s) |\n|---|---|---|\n${rows}`;
               }
             }

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,58 +1,144 @@
 name: Integration Test
 
+# Trusted trigger: runs in the base repo's context (full GITHUB_TOKEN
+# permissions, environment secrets available) regardless of whether the
+# triggering PR came from a fork. This is the privilege-separated
+# counterpart to pr-metadata.yml, which does the untrusted checkout-free
+# bookkeeping. See: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions
+#
+# workflow_run does not automatically attach as a PR status check, so this
+# workflow explicitly creates/updates a Check Run on the PR's head SHA via
+# the Checks API — that's what branch protection actually watches.
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_run:
+    workflows: ["PR Metadata"]
+    types: [completed]
 
 permissions:
   contents: read
   pull-requests: write
+  actions: read
+  checks: write
 
 concurrency:
-  group: integration-test-${{ github.event.pull_request.number }}
+  group: integration-test-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 jobs:
   integration-test:
     name: integration-test
-    if: github.event.pull_request.draft == false
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     environment: integration-test   # gate: waits for reviewer approval here
 
     steps:
+      - name: Download PR metadata
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-metadata
+          path: pr-metadata
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Read PR metadata
+        id: pr
+        run: |
+          if [ "${{ steps.download.outcome }}" != "success" ] || [ ! -s pr-metadata/pr-number ]; then
+            # PR Metadata's record-pr job was skipped (e.g. draft PR) and produced no
+            # artifact — nothing to test, exit without creating a check or comment.
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo "found=true"
+            echo "number=$(cat pr-metadata/pr-number)"
+            echo "sha=$(cat pr-metadata/pr-sha)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create pending check run
+        if: steps.pr.outputs.found == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'integration-test',
+              head_sha: '${{ steps.pr.outputs.sha }}',
+              status: 'in_progress',
+              details_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });
+
       - name: Checkout PR head
+        if: steps.pr.outputs.found == 'true'
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: refs/pull/${{ steps.pr.outputs.number }}/head
+
+      - name: Verify checked-out SHA matches recorded PR head
+        if: steps.pr.outputs.found == 'true'
+        run: |
+          actual="$(git rev-parse HEAD)"
+          expected="${{ steps.pr.outputs.sha }}"
+          if [ "$actual" != "$expected" ]; then
+            echo "Checked-out SHA ($actual) does not match PR metadata ($expected) — PR head moved since pr-metadata ran, refusing to run privileged tests against a stale checkout." >&2
+            exit 1
+          fi
 
       - name: Setup Go
+        if: steps.pr.outputs.found == 'true'
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true
 
       - name: Setup Terraform
+        if: steps.pr.outputs.found == 'true'
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_wrapper: false
 
       - name: Run acceptance tests against live endpoint
+        if: steps.pr.outputs.found == 'true'
         env:
           TF_VAR_observability_token: ${{ secrets.TF_VAR_OBSERVABILITY_TOKEN }}
           TF_VAR_realm: ${{ secrets.TF_VAR_REALM }}
           TF_VAR_rigor_token: ${{ secrets.TF_VAR_RIGOR_TOKEN }}
         run: make testacc
 
-      - name: Post result to PR
-        if: always()
+      - name: Report check run result
+        if: always() && steps.pr.outputs.found == 'true'
         uses: actions/github-script@v7
         with:
           script: |
             const status = '${{ job.status }}';
+            const conclusion = status === 'success' ? 'success' : 'failure';
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            const checks = await github.rest.checks.listForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: '${{ steps.pr.outputs.sha }}',
+              check_name: 'integration-test',
+            });
+            const check = checks.data.check_runs[0];
+            if (check) {
+              await github.rest.checks.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                check_run_id: check.id,
+                status: 'completed',
+                conclusion,
+                details_url: runUrl,
+              });
+            }
+
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: `### Integration Test: ${status === 'success' ? '✅ Passed' : '❌ Failed'}\n\n[View run](${runUrl})`,
+              issue_number: ${{ steps.pr.outputs.number }},
+              body: `### Integration Test: ${conclusion === 'success' ? '✅ Passed' : '❌ Failed'}\n\n[View run](${runUrl})`,
             });

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -28,6 +28,8 @@ jobs:
         with:
           name: pr-metadata
           path: pr-metadata/
-          # Must outlive the integration-test environment's approval wait, or the
-          # artifact expires while a reviewer is still deciding — see integration-test.yml.
-          retention-days: 14
+          # integration-test.yml's ungated `resolve` job downloads and validates this
+          # artifact immediately on workflow_run, before any approval wait — so this only
+          # needs to survive normal workflow_run delivery/retry latency, not the (up to
+          # 30-day) environment approval SLA. Keeping several days as a rerun buffer.
+          retention-days: 3

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -28,4 +28,6 @@ jobs:
         with:
           name: pr-metadata
           path: pr-metadata/
-          retention-days: 1
+          # Must outlive the integration-test environment's approval wait, or the
+          # artifact expires while a reviewer is still deciding — see integration-test.yml.
+          retention-days: 14

--- a/.github/workflows/pr-metadata.yml
+++ b/.github/workflows/pr-metadata.yml
@@ -1,0 +1,31 @@
+name: PR Metadata
+
+# Untrusted trigger: runs for PRs from forks with no secrets and read-only
+# permissions. Its only job is to record which PR/SHA to test, so the
+# privileged integration-test workflow (triggered via workflow_run) never has
+# to check out or execute anything from this workflow's own run context.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+
+jobs:
+  record-pr:
+    name: record-pr
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write PR metadata
+        run: |
+          mkdir -p pr-metadata
+          echo "${{ github.event.pull_request.number }}" > pr-metadata/pr-number
+          echo "${{ github.event.pull_request.head.sha }}" > pr-metadata/pr-sha
+
+      - name: Upload PR metadata
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-metadata
+          path: pr-metadata/
+          retention-days: 1

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -52,5 +52,6 @@ test:
 	go test -i $(TEST) || exit 1                                                   
 	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4                    
 
-testacc: 
-	TF_ACC=1 go test $(TEST) $(TESTARGS) -timeout 120m   | sed '/X-Sf-Token/d'
+testacc: SHELL:=/bin/bash
+testacc:
+	set -o pipefail; TF_ACC=1 go test $(TEST) $(TESTARGS) -timeout 120m | sed '/X-Sf-Token/d'

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -54,4 +54,4 @@ test:
 
 testacc: SHELL:=/bin/bash
 testacc:
-	set -o pipefail; TF_ACC=1 go test $(TEST) $(TESTARGS) -timeout 120m | sed '/X-Sf-Token/d'
+	set -o pipefail; TF_ACC=1 go test $(TEST) $(TESTARGS) -timeout 30m | sed '/X-Sf-Token/d'

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -54,4 +54,7 @@ test:
 
 testacc: SHELL:=/bin/bash
 testacc:
-	set -o pipefail; TF_ACC=1 go test $(TEST) $(TESTARGS) -timeout 30m | sed '/X-Sf-Token/d'
+	set -o pipefail; TF_ACC=1 go test -json $(TEST) $(TESTARGS) -timeout 30m \
+		| sed '/X-Sf-Token/d' \
+		| tee testacc.jsonl \
+		| jq -j -r 'if .Action == "output" then .Output else empty end'


### PR DESCRIPTION
## Summary
- Adds a gated integration test workflow that runs `make testacc` (real acceptance tests) against the live Splunk Observability/Rigor endpoints for every non-draft pull request.
- The job runs under a protected `integration-test` GitHub Environment: it pauses for required-reviewer approval before any secrets are decrypted, so live credentials are only exposed for the duration of an explicitly approved run.
- Split into two workflows for privilege separation:
  - [`pr-metadata.yml`](.github/workflows/pr-metadata.yml) — untrusted, triggered on `pull_request`. Runs with no secrets and `contents: read` only. Its sole job is to record the PR number/head SHA and upload them as an artifact.
  - [`integration-test.yml`](.github/workflows/integration-test.yml) — trusted, triggered via `workflow_run` on `pr-metadata.yml`'s completion. Always runs in the base repo's context, so it has real secrets and a full `GITHUB_TOKEN` regardless of whether the triggering PR came from a fork.
- Before running tests, it verifies the checked-out SHA matches the SHA recorded by `pr-metadata.yml`, so a stale approval can't be used to run privileged tests against a PR head that moved after approval.
- Since `workflow_run` jobs don't auto-attach as PR status checks, the workflow explicitly creates/updates a Check Run via the Checks API on the PR's head SHA — that's what branch protection watches.
- Result is posted back as a PR comment, including a **per-test results table** (pass/fail/skip + duration) parsed from `go test -json` output, plus pass/fail counts and a link to the run.
  - The table only reports **live acceptance tests** (the `TestAcc*` naming convention every `resource.Test`/`resource.ParallelTest` caller in this repo follows). Unit tests still run as part of `make testacc` and still fail the job (and the required check) via `pipefail` if any fail — they're just not surfaced in the comment table, since the reviewer approving a live-endpoint run only needs to see what happened against the live endpoint.
- Draft PRs are skipped; the workflow re-triggers via `ready_for_review` when a PR exits draft.

## Security concerns addressed
- **Secrets never touch an untrusted context.** `TF_VAR_OBSERVABILITY_TOKEN`, `TF_VAR_REALM`, and `TF_VAR_RIGOR_TOKEN` are environment secrets scoped to `integration-test`, injected only as step-level env vars on the trusted `workflow_run` job — never on the fork-triggerable `pull_request` job, never written to disk, never passed as workflow inputs. Values are auto-masked by the runner in logs.
- **Fork PRs can't forge a privileged run.** Because `pr-metadata.yml` never checks out or executes anything from PR content, and `integration-test.yml` validates the PR number/SHA it recorded against GitHub-computed fields and the API before trusting them (see review follow-ups below), a fork PR gets real secrets and a write-capable token *only* after a required reviewer approves — closing the gap where a plain `pull_request`-triggered job would otherwise be able to exfiltrate secrets via a malicious workflow diff.
- **Approval can't be replayed against a moved PR head.** The explicit SHA-match check before running `make testacc` prevents a reviewer's approval of commit A from being used to run tests (and expose secrets) against a since-pushed commit B.
- **Tampering with the workflow file itself is blocked at the repo level.** "Require approval for all external contributors" is enabled under Settings → Actions → General, so a fork PR that edits `integration-test.yml` still requires maintainer approval before it can run at all.
- **The API token is redacted from all captured output.** `make testacc` pipes `go test -json` through `sed '/X-Sf-Token/d'` before anything is persisted to `testacc.jsonl` or read by the results-table step — the live API echoes this header, and the redaction happens upstream of every consumer, including the new PR-comment table.
- **A swallowed test failure can no longer pass the gate.** The original `go test | sed` pipe under `make`'s default `/bin/sh` returned `sed`'s exit code (always 0), so the job — and the required check — could go green even when acceptance tests failed. Fixed via `SHELL:=/bin/bash` + `set -o pipefail` on the `testacc` target.

## Review follow-ups
Addressed in response to review comments on the artifact-trust boundary between the untrusted `pr-metadata.yml` and the privileged `integration-test.yml`:
- **Don't trust the artifact's own claims about itself.** `pr-metadata.yml` is a `pull_request`-triggered workflow, so a fork PR can rewrite that *file* to upload an arbitrary `pr-number`/`pr-sha` pair. `integration-test.yml` now validates the downloaded artifact before using it: strict regex checks on both fields, and the SHA is cross-checked against `github.event.workflow_run.head_sha` (a value GitHub itself computes for the triggering commit, independent of anything the artifact's own script produced). Any mismatch now fails the job loudly instead of silently proceeding.
- **Resolve the claimed PR by number, then verify every trust-relevant field — don't rely on commit-associated PR lookups or the `workflow_run` payload's own PR linkage.** The artifact's `pr-number` is now used only to fetch that PR directly (`pulls.get`), and the result must independently satisfy: `state == 'open'`, `head.sha == workflow_run.head_sha`, `head.repo.full_name == workflow_run.head_repository.full_name`, `head.ref == workflow_run.head_branch`, and `base.repo.full_name == this repo`. This replaced an earlier version that used `repos.listPullRequestsAssociatedWithCommit`, which can return multiple open/merged PRs sharing a commit (letting a forged artifact redirect handling to an unrelated but-also-matching PR). We deliberately didn't switch to trusting `workflow_run.pull_requests` directly either — that field is documented to come back empty for PRs from forked repositories, which is exactly the case this workflow exists to support.
- **Move privileged values out of interpolated script/command text.** `pr-sha`, `pr-number`, and `job.status` were being spliced directly into `github-script` JS and shell `run:` blocks via `${{ }}`, which is a script-injection vector for any value that isn't fully trusted yet at that point in the job. These are now passed through `env:` and read via `process.env.*` / `$VAR` instead.
- **Stop persisting the write-scoped token past its need.** Added `persist-credentials: false` to the "Checkout PR head" step, so `make testacc` (which runs PR-controlled code) can no longer read the `checks: write` / `pull-requests: write`-scoped `GITHUB_TOKEN` out of the git credential store.
- **Fail loudly instead of silently on missing/malformed metadata.** Removed the `continue-on-error: true` / "found=false" fallback path. Empirically verified (see below) that a draft PR's skipped `record-pr` job makes the whole `PR Metadata` workflow run report `conclusion: skipped`, not `success` — so `integration-test.yml`'s existing `if: github.event.workflow_run.conclusion == 'success'` job guard already keeps draft PRs from ever reaching this job, including the environment approval gate. That means reaching the metadata-read step with a missing or malformed artifact is always an anomaly (e.g. artifact expired), never a legitimate "nothing to test" case, so it's now treated as a hard failure.
- **Decouple artifact retention from the environment approval SLA instead of just extending it.** A prior fix bumped `retention-days` from 1 to 14 to survive a slow approval — but GitHub environments allow approval waits of up to 30 days, so 14 days could still expire mid-wait. Rather than push retention past 30 days, the job is now split: an ungated `resolve` job downloads and validates the `pr-metadata` artifact immediately on `workflow_run` (before any approval gate) and exposes its outputs to the job; a separate `integration-test` job (gated by `environment: integration-test`) consumes those outputs and does the actual checkout/test/report. The artifact's retention now only needs to cover normal `workflow_run` delivery/rerun latency, so it's set to 3 days rather than chasing the 30-day ceiling.
- **Finalize the required check when approval is rejected or times out.** Splitting into `resolve`/`integration-test` introduced a new gap: `resolve` creates the check as `queued`, but every status transition after that lived inside `integration-test`'s own steps. If a reviewer rejects the deployment or the approval wait times out, GitHub fails `integration-test` before any of its steps run — including the one that would've marked the check completed — so the check would sit at `queued`/`in_progress` until GitHub marks it stale after 14 days, silently hiding the rejection/timeout from the required check. Added a third job, `finalize-on-incomplete` (`needs: [resolve, integration-test]`, `if: always()`), that closes the check as `failure` and comments on the PR only if it finds the check still open.
  - Initial version's no-op guard was `check.status === 'completed'`, which also matched GitHub's own auto-completion of a stalled check with conclusion `stale` — something GitHub does after 14 days of inactivity, well before the up-to-30-day approval timeout can elapse. That meant a 30-day-timeout rejection produced a `stale` check with no PR comment, silently passing the finalizer's guard. Narrowed the no-op to only the two conclusions `integration-test`'s own reporting step ever sets (`success`, `failure`); anything else — including `stale` — is now finalized as `failure` with the explanatory comment.

### Empirical verification of the draft-PR skip behavior
Opened a real throwaway draft PR (#106, closed and branch deleted immediately after) against this same workflow code to observe actual GitHub behavior rather than relying on documentation:
- The resulting `PR Metadata` run (whose only job, `record-pr`, was skipped because the PR was a draft) reported top-level `conclusion: "skipped"`.
- No corresponding `Integration Test` `workflow_run` was created at all — confirming the job-level `if: github.event.workflow_run.conclusion == 'success'` guard filters this out before the job (and its `environment: integration-test` approval gate) is ever evaluated.

This confirmed the reviewer's proposed failure mode (draft PR reaching the approval gate before discovering there's no artifact) does not currently occur, so no change was needed for that specific concern — the fix effort instead went into the four items above.

## Sample run
A completed run against this PR (prior to the `resolve`/`integration-test` job split), showing the environment-approval gate, `make testacc` output, and the resulting PR comment with the per-test table filtered to live acceptance tests only:
https://github.com/splunk/terraform-provider-synthetics/actions/runs/30678346535

## Requires (repo settings, not part of this diff)
- [x] `integration-test` environment created with required reviewers and the three secrets above
- [x] Branch protection on `main` updated to require the `integration-test` status check before merge
- [x] "Require approval for all external contributors" enabled under Settings → Actions → General, so a fork PR can't execute a tampered workflow without maintainer approval

## Test plan
- [x] Open a PR and confirm the job pauses at "Waiting for review" until a required reviewer approves (validated via a temporary direct `pull_request` trigger on this PR, since `workflow_run` can't fire until this workflow exists on `main`; see sample run above)
- [x] Confirm `make testacc` runs and secrets show as `***` in logs
- [x] Confirm a PR comment is posted with a per-test results table on both pass and fail
- [x] Confirm the results table only lists `TestAcc*` (live) tests and excludes unit-test results, while a failing unit test still fails the job/check
- [x] Confirm a draft PR does not trigger the job, and that marking it ready-for-review does
- [x] Confirm the fork-secrets path end-to-end with an actual fork PR after merge (this PR isn't from a fork, so `workflow_run`'s fork-safety behavior itself is unverified until then)
- [x] Confirm a real draft PR's `PR Metadata` run reports `conclusion: skipped` and never triggers an `Integration Test` run (verified via throwaway PR #106)
- [x] YAML and embedded JS in both workflow files syntax-checked after each metadata-validation revision; `actionlint` passes
- [ ] Confirm the `resolve` → `integration-test` → `finalize-on-incomplete` job split still produces a working approval gate and PR comment end-to-end (needs a fresh run now that the job is split; sample run above predates the split)
- [x] Confirm `finalize-on-incomplete` actually closes the check as failed when a deployment review is explicitly rejected
- [ ] Confirm `finalize-on-incomplete` correctly converts a `stale` check (30-day approval timeout) to `failure` with a PR comment (not practically exercisable pre-merge given the 30-day wait; verified by code inspection and the `stale`-vs-`completed` distinction above)
