### PR TITLE
SYN-6770: Terraform provider - audit and clean full-object debug logs

### DIFF
--- a/synthetics/data_source_devices_v2.go
+++ b/synthetics/data_source_devices_v2.go
@@ -95,7 +95,6 @@ func dataSourceDevicesV2Read(ctx context.Context, d *schema.ResourceData, m inte
 	var diags diag.Diagnostics
 
 	check, _, err := c.GetDevicesV2()
-	println(check)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/synthetics/data_source_downtimeconfiguration_v2.go
+++ b/synthetics/data_source_downtimeconfiguration_v2.go
@@ -144,7 +144,6 @@ func dataSourceDowntimeConfigurationV2Read(ctx context.Context, d *schema.Resour
 	downtimeConfigID := flattenIdData(d.Get("downtime_configuration"))
 
 	downtimeConfig, _, err := c.GetDowntimeConfigurationV2(downtimeConfigID)
-	println(downtimeConfig)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/synthetics/data_source_downtimeconfigurations_v2.go
+++ b/synthetics/data_source_downtimeconfigurations_v2.go
@@ -150,7 +150,6 @@ func dataSourceDowntimeConfigurationsV2Read(ctx context.Context, d *schema.Resou
 	var diags diag.Diagnostics
 
 	downtime_configs, _, err := c.GetDowntimeConfigurationsV2(&downtimeOptions)
-	println(downtime_configs)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/synthetics/data_source_location_v2.go
+++ b/synthetics/data_source_location_v2.go
@@ -93,7 +93,6 @@ func dataSourceLocationV2Read(ctx context.Context, d *schema.ResourceData, m int
 	checkID := flattenStringIdData(d.Get("location"))
 
 	check, _, err := c.GetLocationV2(checkID)
-	println(check)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/synthetics/data_source_locations_v2.go
+++ b/synthetics/data_source_locations_v2.go
@@ -74,7 +74,6 @@ func dataSourceLocationsV2Read(ctx context.Context, d *schema.ResourceData, m in
 	var diags diag.Diagnostics
 
 	check, _, err := c.GetLocationsV2()
-	println(check)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/synthetics/data_source_portcheck_v2.go
+++ b/synthetics/data_source_portcheck_v2.go
@@ -138,7 +138,6 @@ func dataSourcePortCheckV2Read(ctx context.Context, d *schema.ResourceData, m in
 	checkID := flattenIdData(d.Get("test"))
 
 	check, _, err := c.GetPortCheckV2(checkID)
-	println(check)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/synthetics/data_source_variable_v2.go
+++ b/synthetics/data_source_variable_v2.go
@@ -79,7 +79,6 @@ func dataSourceVariableV2Read(ctx context.Context, d *schema.ResourceData, m int
 	checkID := flattenIdData(d.Get("variable"))
 
 	check, _, err := c.GetVariableV2(checkID)
-	println(check)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/synthetics/data_source_variables_v2.go
+++ b/synthetics/data_source_variables_v2.go
@@ -75,7 +75,6 @@ func dataSourceVariablesV2Read(ctx context.Context, d *schema.ResourceData, m in
 	var diags diag.Diagnostics
 
 	check, _, err := c.GetVariablesV2()
-	println(check)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/synthetics/resource_browser_check.go
+++ b/synthetics/resource_browser_check.go
@@ -744,11 +744,11 @@ func resourceBrowserCheckRead(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.FromErr(err)
 	}
 
-	check, _, err := c.GetCheck(checkID)
+	_, _, err = c.GetCheck(checkID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	log.Println("[DEBUG] GET check response data: ", check)
+	log.Println("[DEBUG] read browser check id:", checkID)
 
 	return diags
 }
@@ -765,12 +765,12 @@ func resourceBrowserCheckDelete(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 
-	resp, err := c.DeleteBrowserCheck(checkIdString)
+	_, err = c.DeleteBrowserCheck(checkIdString)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	log.Println("[DEBUG] Delete check response data: ", resp)
+	log.Println("[DEBUG] deleted browser check id:", checkIdString)
 	d.SetId("")
 
 	return diags
@@ -790,11 +790,11 @@ func resourceBrowserCheckUpdate(ctx context.Context, d *schema.ResourceData, met
 		return diag.FromErr(err)
 	}
 
-	o, _, err := c.UpdateBrowserCheck(checkIdString, &checkData)
+	_, _, err = c.UpdateBrowserCheck(checkIdString, &checkData)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	log.Println("[DEBUG] Update check response data: ", o)
+	log.Println("[DEBUG] updated browser check id:", checkIdString)
 	if err := d.Set("last_updated", time.Now().Format(time.RFC850)); err != nil {
 		return diag.FromErr(err)
 	}

--- a/synthetics/resource_downtime_configuration_v2.go
+++ b/synthetics/resource_downtime_configuration_v2.go
@@ -187,7 +187,7 @@ func resourceDowntimeConfigurationV2Read(ctx context.Context, d *schema.Resource
 		log.Println("[WARN] Synthetics API error.", downtimeConfigurationID, err.Error(), r.StatusCode)
 		return diag.FromErr(err)
 	}
-	log.Println("DEBUG] GET downtime_configuration response data: ", downtimeConfiguration)
+	log.Println("[DEBUG] read downtime_configuration id:", downtimeConfigurationID)
 	if err := d.Set("downtime_configuration", flattenDowntimeConfigurationV2Read(downtimeConfiguration)); err != nil {
 		return diag.FromErr(err)
 	}
@@ -207,12 +207,12 @@ func resourceDowntimeConfigurationV2Delete(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 
-	resp, err := c.DeleteDowntimeConfigurationV2(DowntimeConfigurationIdString)
+	_, err = c.DeleteDowntimeConfigurationV2(DowntimeConfigurationIdString)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	log.Println("[DEBUG] Delete downtime_configuration response data: ", resp)
+	log.Println("[DEBUG] deleted downtime_configuration id:", DowntimeConfigurationIdString)
 	d.SetId("")
 
 	return diags
@@ -230,22 +230,17 @@ func resourceDowntimeConfigurationV2Update(ctx context.Context, d *schema.Resour
 		return diag.FromErr(err)
 	}
 
-	o, _, err := c.UpdateDowntimeConfigurationV2(DowntimeConfigurationIdString, &DowntimeConfigurationData)
+	_, _, err = c.UpdateDowntimeConfigurationV2(DowntimeConfigurationIdString, &DowntimeConfigurationData)
 	if err != nil {
-		log.Println("[ERROR] downtime_configuration failed to update. Dumping request data: ", o)
+		log.Println("[ERROR] downtime_configuration failed to update id:", DowntimeConfigurationIdString)
 		return diag.FromErr(err)
 	}
 
-	log.Println("[DEBUG] Update downtime_configuration response data: ", o)
+	log.Println("[DEBUG] updated downtime_configuration id:", DowntimeConfigurationIdString)
 	return resourceDowntimeConfigurationV2Read(ctx, d, meta)
 }
 
 func processDowntimeConfigurationV2Items(d *schema.ResourceData) sc2.DowntimeConfigurationV2Input {
-
-	log.Println("[DEBUG] Process downtime_configuration Resource Data: ", d)
-
 	var downtimeConfig = buildDowntimeConfigurationV2Data(d)
-
-	log.Println("[DEBUG] Processed downtime_configuration Resource Data OUTPUT: ", downtimeConfig)
 	return downtimeConfig
 }

--- a/synthetics/resource_http_check.go
+++ b/synthetics/resource_http_check.go
@@ -444,11 +444,11 @@ func resourceHttpCheckRead(ctx context.Context, d *schema.ResourceData, meta int
 		return diag.FromErr(err)
 	}
 
-	check, _, err := c.GetHttpCheck(checkID)
+	_, _, err = c.GetHttpCheck(checkID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	log.Println("[DEBUG] GET check response data: ", check)
+	log.Println("[DEBUG] read http check id:", checkID)
 
 	return diags
 }
@@ -465,12 +465,12 @@ func resourceHttpCheckDelete(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 
-	resp, err := c.DeleteHttpCheck(checkIdString)
+	_, err = c.DeleteHttpCheck(checkIdString)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	log.Println("[DEBUG] Delete check response data: ", resp)
+	log.Println("[DEBUG] deleted http check id:", checkIdString)
 	d.SetId("")
 
 	return diags
@@ -490,11 +490,11 @@ func resourceHttpCheckUpdate(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.FromErr(err)
 	}
 
-	o, _, err := c.UpdateHttpCheck(checkIdString, &checkData)
+	_, _, err = c.UpdateHttpCheck(checkIdString, &checkData)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	log.Println("[DEBUG] Update check response data: ", o)
+	log.Println("[DEBUG] updated http check id:", checkIdString)
 	if err := d.Set("last_updated", time.Now().Format(time.RFC850)); err != nil {
 		return diag.FromErr(err)
 	}

--- a/synthetics/resource_location_v2.go
+++ b/synthetics/resource_location_v2.go
@@ -88,7 +88,7 @@ func resourceLocationV2Create(ctx context.Context, d *schema.ResourceData, meta 
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	log.Println("DEBUG] LOCATION ID IS: ", o.ID)
+	log.Println("[DEBUG] created location id:", o.ID)
 	d.SetId(o.ID)
 
 	resourceLocationV2Read(ctx, d, meta)
@@ -115,7 +115,7 @@ func resourceLocationV2Read(ctx context.Context, d *schema.ResourceData, meta in
 		log.Println("[WARN] Synthetics API error.", locationID, err.Error(), r.StatusCode)
 		return diag.FromErr(err)
 	}
-	log.Println("DEBUG] GET location response data: ", location)
+	log.Println("[DEBUG] read location id:", locationID)
 	if err := d.Set("location", flattenLocationV2Data(location.Location)); err != nil {
 		return diag.FromErr(err)
 	}
@@ -132,23 +132,18 @@ func resourceLocationV2Delete(ctx context.Context, d *schema.ResourceData, meta 
 
 	var locationIdString = locationID
 
-	resp, err := c.DeleteLocationV2(locationIdString)
+	_, err := c.DeleteLocationV2(locationIdString)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	log.Println("[DEBUG] Delete location response data: ", resp)
+	log.Println("[DEBUG] deleted location id:", locationIdString)
 	d.SetId("")
 
 	return diags
 }
 
 func processLocationV2Items(d *schema.ResourceData) sc2.LocationV2Input {
-
-	log.Println("[DEBUG] Process Location Resource Data: ", d)
-
 	var check = buildLocationV2Data(d)
-
-	log.Println("[DEBUG] Processed Location Resource Data OUTPUT: ", check)
 	return check
 }

--- a/synthetics/resource_port_check_v2.go
+++ b/synthetics/resource_port_check_v2.go
@@ -176,7 +176,7 @@ func resourcePortCheckV2Read(ctx context.Context, d *schema.ResourceData, meta i
 		log.Println("[WARN] Synthetics API error.", checkID, err.Error(), r.StatusCode)
 		return diag.FromErr(err)
 	}
-	log.Println("[DEBUG] GET PORT BODY: ", o)
+	log.Println("[DEBUG] read port check id:", checkID)
 	if err := d.Set("test", flattenPortCheckV2Read(o)); err != nil {
 		return diag.FromErr(err)
 	}
@@ -196,12 +196,12 @@ func resourcePortCheckV2Delete(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
-	resp, err := c.DeletePortCheckV2(checkIdString)
+	_, err = c.DeletePortCheckV2(checkIdString)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	log.Println("[DEBUG] Delete check response data: ", resp)
+	log.Println("[DEBUG] deleted port check id:", checkIdString)
 	d.SetId("")
 
 	return diags
@@ -219,18 +219,16 @@ func resourcePortCheckV2Update(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
-	o, _, err := c.UpdatePortCheckV2(checkIdString, &checkData)
+	_, _, err = c.UpdatePortCheckV2(checkIdString, &checkData)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	log.Println("[DEBUG] UPDATE BODY: ", o)
+	log.Println("[DEBUG] updated port check id:", checkIdString)
 
 	return resourcePortCheckV2Read(ctx, d, meta)
 }
 
 func processPortCheckV2Items(d *schema.ResourceData) sc2.PortCheckV2Input {
-
 	var check = buildPortCheckV2Data(d)
-	log.Println("[DEBUG] PORT V2 CHECK OUTPUT: ", check)
 	return check
 }

--- a/synthetics/resource_variable_v2.go
+++ b/synthetics/resource_variable_v2.go
@@ -121,7 +121,7 @@ func resourceVariableV2Read(ctx context.Context, d *schema.ResourceData, meta in
 		log.Println("[WARN] Synthetics API error.", variableID, err.Error(), r.StatusCode)
 		return diag.FromErr(err)
 	}
-	log.Println("DEBUG] GET variable response data: ", variable)
+	log.Println("[DEBUG] read variable id:", variableID)
 	if err := d.Set("variable", flattenVariableV2Read(variable)); err != nil {
 		return diag.FromErr(err)
 	}
@@ -141,12 +141,12 @@ func resourceVariableV2Delete(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.FromErr(err)
 	}
 
-	resp, err := c.DeleteVariableV2(variableIdString)
+	_, err = c.DeleteVariableV2(variableIdString)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	log.Println("[DEBUG] Delete variable response data: ", resp)
+	log.Println("[DEBUG] deleted variable id:", variableIdString)
 	d.SetId("")
 
 	return diags
@@ -164,22 +164,17 @@ func resourceVariableV2Update(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.FromErr(err)
 	}
 
-	o, _, err := c.UpdateVariableV2(variableIdString, &variableData)
+	_, _, err = c.UpdateVariableV2(variableIdString, &variableData)
 	if err != nil {
-		log.Println("[ERROR] Variable failed to update. Dumping request data: ", o)
+		log.Println("[ERROR] variable failed to update id:", variableIdString)
 		return diag.FromErr(err)
 	}
 
-	log.Println("[DEBUG] Update variable response data: ", o)
+	log.Println("[DEBUG] updated variable id:", variableIdString)
 	return resourceVariableV2Read(ctx, d, meta)
 }
 
 func processVariableV2Items(d *schema.ResourceData) sc2.VariableV2Input {
-
-	log.Println("[DEBUG] Process Variable Resource Data: ", d)
-
 	var check = buildVariableV2Data(d)
-
-	log.Println("[DEBUG] Processed Variable Resource Data OUTPUT: ", check)
 	return check
 }


### PR DESCRIPTION
## Summary

Security-hygiene follow-up split out of SYN-3601 (HTTP V2 port support). Audits provider-level logging across resources and data sources for statements that emit full request, response, resource, or client objects, and narrows them to safe metadata (operation name, resource type, ID). Does not touch client-layer redaction logic (already covered by `client_redaction_test.go`), SYN-3601's HTTP V2 port behavior, or vendored client code.

## Changes

**Full-object debug logs narrowed to ID-only metadata:**

- `resource_location_v2.go` — create/read logs no longer dump `o`/`location`; delete no longer logs the full delete response; `processLocationV2Items` no longer logs raw `d` (ResourceData) or the built `check` struct.
- `resource_downtime_configuration_v2.go` — read log no longer dumps `downtimeConfiguration`; delete no longer logs the full response; update no longer dumps `o` (request data) on failure or success; `processDowntimeConfigurationV2Items` no longer logs `d`/`downtimeConfig`.
- `resource_variable_v2.go` — read log no longer dumps `variable` (GET), which can include a secret `value`; delete no longer logs the full response; update no longer dumps `o` (request data, may include the variable value) on failure or success; `processVariableV2Items` no longer logs `d`/`check`.
- `resource_port_check_v2.go` — read/update logs no longer dump the full check/response body (`o`); delete no longer logs the full response; `processPortCheckV2Items` no longer logs the built `check` struct.
- `resource_browser_check.go` (v1) — read/update/delete no longer log full check/response structs.
- `resource_http_check.go` (v1) — read/update/delete no longer log full check/response structs, which can include `HTTPRequestHeaders`, `HTTPRequestBody`, and `URL`.

All replaced with `log.Println("[DEBUG] <verb> <resource> id:", id)` (or `[ERROR]`/`[WARN]` equivalents on failure paths), matching the style already used elsewhere in the provider.

**Removed raw `println(...)` calls** in 8 data source files — these only printed a Go pointer address (no real debug value) and risked leaking sensitive fields if struct layout or `println` behavior changed:

- `data_source_devices_v2.go`
- `data_source_downtimeconfiguration_v2.go`
- `data_source_downtimeconfigurations_v2.go`
- `data_source_location_v2.go`
- `data_source_locations_v2.go`
- `data_source_portcheck_v2.go`
- `data_source_variable_v2.go` — important, `check` includes a potential secret `value`
- `data_source_variables_v2.go` — important, list may include secret `value`s

**Audited, no changes needed** (confirmed via full-repo grep sweep — these already log only checkID/err/status/counts, never full structs): `resource_api_check_v2.go`, `resource_ssl_check_v2.go`, `resource_http_check_v2.go`, `resource_client_certificate_v2.go`, `resource_ca_certificate_v2.go`, `resource_totp_variable_v2.go`, `resource_browser_check_v2.go`, `structures.go`.

## Validation

- `go build ./...` — passes with no errors.
- `go vet ./...` — passes with no errors.
- `go test ./...` — all existing tests pass, including `client_redaction_test.go` (verifies client-layer redaction of API tokens and CA certificate content, unaffected by this change).
- Manual grep sweep of the full module (`log.Printf|log.Println|fmt.Println|println(`) confirms no remaining call site logs a full request/response/check/resource-data struct; all remaining `log.Printf` calls in provider code use only scalar format verbs (`%d`, `%s`) against IDs/counts, never `%v`/`%+v` against structs.
- No changes to SYN-3601 HTTP V2 port logic, no vendored client edits, no unrelated refactors — diff is 14 files / 33 insertions / 58 deletions, scoped entirely to logging statements.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Manual review of full diff to confirm no full-object logs remain and no behavior outside logging changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)