### PR TITLE
SYN-6879: fix HTTP header removal and support valueless Chrome flags

### DIFF
--- a/docs/resources/create_browser_check_v2.md
+++ b/docs/resources/create_browser_check_v2.md
@@ -252,7 +252,7 @@ Optional:
 Optional:
 
 - `name` (String)
-- `value` (String)
+- `value` (String) Omit or leave empty for flags that are valid without a value (e.g. `--disable-web-security`); a flag with no `value` is sent to the API distinctly from one with an explicit empty string.
 
 
 <a id="nestedblock--test--advanced_settings--cookies"></a>

--- a/examples/resources/synthetics_create_browser_check_v2/resource.tf
+++ b/examples/resources/synthetics_create_browser_check_v2/resource.tf
@@ -139,6 +139,13 @@ resource "synthetics_create_browser_check_v2" "long_browser_v2_foo_check" {
         type  = "custom"
         regex = "cdn\\.example\\.com"
       }
+      chrome_flags {
+        name = "--disable-web-security"
+      }
+      chrome_flags {
+        name  = "--proxy-bypass-list"
+        value = "127.0.0.1:8080"
+      }
       headers {
         name = "superstar-machine"
         value = "\"taking it too the staaaaars\""

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/splunk/syntheticsclient v1.0.3
-	github.com/splunk/syntheticsclient/v2 v2.7.0
+	github.com/splunk/syntheticsclient/v2 v2.7.1-0.20260804043817-13fce789c3b0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
 	github.com/splunk/syntheticsclient v1.0.3
-	github.com/splunk/syntheticsclient/v2 v2.7.1-0.20260804043817-13fce789c3b0
+	github.com/splunk/syntheticsclient/v2 v2.8.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -176,6 +176,8 @@ github.com/splunk/syntheticsclient v1.0.3 h1:I3PUgTnKZsCNGFH8OgBiQ+sZYYxOwcLmkbi
 github.com/splunk/syntheticsclient v1.0.3/go.mod h1:riH4plM9ySr2lHnWi2E4cocaP9qqlRQHKX6nisiyq6E=
 github.com/splunk/syntheticsclient/v2 v2.7.0 h1:KC9DhBGqOIfBQBMZmWyLLfASByfKBX4of+rlQlcJwWU=
 github.com/splunk/syntheticsclient/v2 v2.7.0/go.mod h1:zW4yCT2gP3MLvUwf95UyBfQJLiSnrRLpufH+VF80Q/A=
+github.com/splunk/syntheticsclient/v2 v2.7.1-0.20260804043817-13fce789c3b0 h1:fM+FBJE0lrHusHLMPdM2PxWyAgOrsNpq8165E5w58YE=
+github.com/splunk/syntheticsclient/v2 v2.7.1-0.20260804043817-13fce789c3b0/go.mod h1:zW4yCT2gP3MLvUwf95UyBfQJLiSnrRLpufH+VF80Q/A=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/go.sum
+++ b/go.sum
@@ -174,10 +174,8 @@ github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMB
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/splunk/syntheticsclient v1.0.3 h1:I3PUgTnKZsCNGFH8OgBiQ+sZYYxOwcLmkbi3mp0Qq78=
 github.com/splunk/syntheticsclient v1.0.3/go.mod h1:riH4plM9ySr2lHnWi2E4cocaP9qqlRQHKX6nisiyq6E=
-github.com/splunk/syntheticsclient/v2 v2.7.0 h1:KC9DhBGqOIfBQBMZmWyLLfASByfKBX4of+rlQlcJwWU=
-github.com/splunk/syntheticsclient/v2 v2.7.0/go.mod h1:zW4yCT2gP3MLvUwf95UyBfQJLiSnrRLpufH+VF80Q/A=
-github.com/splunk/syntheticsclient/v2 v2.7.1-0.20260804043817-13fce789c3b0 h1:fM+FBJE0lrHusHLMPdM2PxWyAgOrsNpq8165E5w58YE=
-github.com/splunk/syntheticsclient/v2 v2.7.1-0.20260804043817-13fce789c3b0/go.mod h1:zW4yCT2gP3MLvUwf95UyBfQJLiSnrRLpufH+VF80Q/A=
+github.com/splunk/syntheticsclient/v2 v2.8.0 h1:DYVHu4CB0yBlUAOK2QPgp5s30wcS+2LEBIPOQokv/vY=
+github.com/splunk/syntheticsclient/v2 v2.8.0/go.mod h1:zW4yCT2gP3MLvUwf95UyBfQJLiSnrRLpufH+VF80Q/A=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/synthetics/resource_browser_check_v2_test.go
+++ b/synthetics/resource_browser_check_v2_test.go
@@ -466,6 +466,51 @@ resource "synthetics_create_browser_check_v2" "browser_v2_foo_check" {
 }
 `
 
+const valuelessChromeFlagBrowserCheckV2Config = `
+resource "synthetics_create_variable_v2" "variable_v2_foo" {
+  provider = synthetics.synthetics
+  variable {
+    description = "The most awesome variable. Full of snakes."
+    value = "barv3v3"
+    name = "acceptance-variable-terraform-test"
+    secret = false
+  }
+}
+resource "synthetics_create_browser_check_v2" "browser_v2_foo_check" {
+  provider = synthetics.synthetics
+  depends_on = [synthetics_create_variable_v2.variable_v2_foo]
+  test {
+    active = false
+    device_id = 2
+    frequency = 15
+    location_ids = ["aws-us-west-2"]
+    automatic_retries = 0
+    name = "01-acceptance-valueless-chrome-flag-Terraform-Browser-V2"
+    scheduling_strategy = "concurrent"
+    advanced_settings {
+      verify_certificates = true
+      user_agent = "Jozilla/5.0"
+      collect_interactive_metrics = false
+      chrome_flags {
+        name = "--disable-web-security"
+      }
+      chrome_flags {
+        name  = "--proxy-bypass-list"
+        value = "127.0.0.1:8080"
+      }
+    }
+    transactions {
+      name = "01 First Synthetic transaction"
+      steps {
+        name = "01 Go to URL"
+        type = "go_to_url"
+        url  = "https://www.splunk.com"
+      }
+    }
+  }
+}
+`
+
 func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
@@ -732,6 +777,22 @@ func TestAccCreateUpdateBrowserCheckV2(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.verify_certificates", "true"),
 					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.excluded_files.#", "0"),
+				),
+			},
+			// A valueless chrome flag round-trips with an empty value, alongside
+			// a flag that still carries one (SYN-6879 / GitHub #82).
+			{
+				Config: providerConfig + valuelessChromeFlagBrowserCheckV2Config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.chrome_flags.#", "2"),
+					resource.TestCheckTypeSetElemNestedAttrs("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.chrome_flags.*", map[string]string{
+						"name":  "--disable-web-security",
+						"value": "",
+					}),
+					resource.TestCheckTypeSetElemNestedAttrs("synthetics_create_browser_check_v2.browser_v2_foo_check", "test.0.advanced_settings.0.chrome_flags.*", map[string]string{
+						"name":  "--proxy-bypass-list",
+						"value": "127.0.0.1:8080",
+					}),
 				),
 			},
 		},

--- a/synthetics/resource_http_check_v2_test.go
+++ b/synthetics/resource_http_check_v2_test.go
@@ -113,7 +113,89 @@ resource "synthetics_create_http_check_v2" "http_v2_foo_check" {
 				expected = 400
 				type = "assert_numeric"
 		}
-  }    
+  }
+}
+`
+
+const httpCheckV2OneHeaderRemovedConfig = `
+resource "synthetics_create_http_check_v2" "http_v2_foo_check" {
+	provider = synthetics.synthetics
+  test {
+    active = false
+    frequency = 15
+    location_ids = ["aws-us-west-2"]
+    name = "01-acceptance-updated-Terraform-HTTP-V2"
+    type = "http"
+    url = "https://www.duckduckgo.com"
+    port = 8443
+    automatic_retries = 0
+    scheduling_strategy = "concurrent"
+		custom_properties {
+			key = "beepkey"
+			value = "boopvalue"
+		}
+    request_method = "PUT"
+    verify_certificates = false
+    user_agent = "Another User of Agents and snake oil"
+    body = "boopboopboop"
+		headers {
+			name = "back_transaction_01"
+			value = "peekoboot"
+		}
+		validations {
+				name = "002 My validation step"
+				actual = "{{response.body}}"
+				comparator = "matches"
+				expected = "12221"
+				type = "assert_string"
+		}
+		validations {
+				name = "My validation step 001"
+				actual = "{{response.code}}"
+				comparator = "does_not_equal"
+				expected = 400
+				type = "assert_numeric"
+		}
+  }
+}
+`
+
+const httpCheckV2AllHeadersRemovedConfig = `
+resource "synthetics_create_http_check_v2" "http_v2_foo_check" {
+	provider = synthetics.synthetics
+  test {
+    active = false
+    frequency = 15
+    location_ids = ["aws-us-west-2"]
+    name = "01-acceptance-updated-Terraform-HTTP-V2"
+    type = "http"
+    url = "https://www.duckduckgo.com"
+    port = 8443
+    automatic_retries = 0
+    scheduling_strategy = "concurrent"
+		custom_properties {
+			key = "beepkey"
+			value = "boopvalue"
+		}
+    request_method = "PUT"
+    verify_certificates = false
+    user_agent = "Another User of Agents and snake oil"
+    body = "boopboopboop"
+		validations {
+				name = "002 My validation step"
+				actual = "{{response.body}}"
+				comparator = "matches"
+				expected = "12221"
+				type = "assert_string"
+		}
+		validations {
+				name = "My validation step 001"
+				actual = "{{response.code}}"
+				comparator = "does_not_equal"
+				expected = 400
+				type = "assert_numeric"
+		}
+  }
 }
 `
 
@@ -212,6 +294,23 @@ func TestAccCreateUpdateHttpCheckV2(t *testing.T) {
 				Config: providerConfig + strings.Replace(updatedHttpCheckV2Config, "    port = 8443\n", "", 1),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.port", "0"),
+				),
+			},
+			// Remove one of the two headers (SYN-6879 / GitHub #73).
+			{
+				Config: providerConfig + httpCheckV2OneHeaderRemovedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.headers.#", "1"),
+					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.headers.0.name", "back_transaction_01"),
+					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.headers.0.value", "peekoboot"),
+				),
+			},
+			// Remove all remaining headers; the API must actually clear them,
+			// not just accept a request that omits the field (SYN-6879 / GitHub #73).
+			{
+				Config: providerConfig + httpCheckV2AllHeadersRemovedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("synthetics_create_http_check_v2.http_v2_foo_check", "test.0.headers.#", "0"),
 				),
 			},
 		},

--- a/synthetics/structures.go
+++ b/synthetics/structures.go
@@ -1400,9 +1400,13 @@ func flattenChromeFlagsData(chromeFlags []sc2.ChromeFlag) []interface{} {
 
 	var result []interface{}
 	for _, flag := range chromeFlags {
+		value := ""
+		if flag.Value != nil {
+			value = *flag.Value
+		}
 		flagData := map[string]interface{}{
 			"name":  flag.Name,
-			"value": flag.Value,
+			"value": value,
 		}
 		result = append(result, flagData)
 	}
@@ -2423,7 +2427,7 @@ func buildBusinessTransactionsData(businessTransactions []interface{}) ([]sc2.Tr
 	return businessTransactionsList, nil
 }
 
-func buildHttpHeadersData(httpHeaders *schema.Set) []sc2.HttpHeaders {
+func buildHttpHeadersData(httpHeaders *schema.Set) *[]sc2.HttpHeaders {
 	httpHeadersList := make([]sc2.HttpHeaders, len(httpHeaders.List()))
 
 	for i, httpHeads := range httpHeaders.List() {
@@ -2438,7 +2442,7 @@ func buildHttpHeadersData(httpHeaders *schema.Set) []sc2.HttpHeaders {
 		httpHeadersList[i] = headerValues
 
 	}
-	return httpHeadersList
+	return &httpHeadersList
 }
 
 func buildCustomPropertiesData(customProperties *schema.Set) []sc2.CustomProperties {
@@ -2621,9 +2625,13 @@ func buildChromeFlagsData(d *schema.Set) []sc2.ChromeFlag {
 	var flags []sc2.ChromeFlag
 	for _, item := range d.List() {
 		data := item.(map[string]interface{})
+		var value *string
+		if v := data["value"].(string); v != "" {
+			value = &v
+		}
 		flags = append(flags, sc2.ChromeFlag{
 			Name:  data["name"].(string),
-			Value: data["value"].(string),
+			Value: value,
 		})
 	}
 	return flags

--- a/synthetics/structures_test.go
+++ b/synthetics/structures_test.go
@@ -760,6 +760,123 @@ func TestHttpV2PortSchemas(t *testing.T) {
 	}
 }
 
+// Reproduces SYN-6879 / GitHub #73: clearing all headers must still be sent
+// to the API as an explicit empty list, not omitted entirely.
+func TestBuildHttpV2DataEmitsExplicitEmptyHeadersOnRemoval(t *testing.T) {
+	d := httpV2ResourceDataForPortTest(t, true, 443)
+
+	got := buildHttpV2Data(d)
+
+	if got.Test.HttpHeaders == nil {
+		t.Fatalf("HttpHeaders = nil, want non-nil empty slice so the API receives an explicit removal")
+	}
+	if len(*got.Test.HttpHeaders) != 0 {
+		t.Fatalf("HttpHeaders = %#v, want empty", *got.Test.HttpHeaders)
+	}
+
+	body, err := json.Marshal(got)
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if !strings.Contains(string(body), `"headers":[]`) {
+		t.Fatalf("request JSON = %s, want explicit \"headers\":[] so the API clears existing headers", string(body))
+	}
+}
+
+// Reproduces SYN-6879 / GitHub #82: Chrome flags that are valid without a
+// value (e.g. --disable-web-security) must round-trip distinctly from a
+// flag carrying an empty-string value.
+func TestChromeFlagsSupportValuelessFlags(t *testing.T) {
+	settings := schema.NewSet(schema.HashResource(browserCheckV2AdvancedSettingsResource(false)), []interface{}{
+		map[string]interface{}{
+			"user_agent":                  "",
+			"verify_certificates":         true,
+			"collect_interactive_metrics": false,
+			"authentication":              schema.NewSet(schema.HashString, nil),
+			"chrome_flags": schema.NewSet(schema.HashResource(&schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name":  {Type: schema.TypeString, Optional: true},
+					"value": {Type: schema.TypeString, Optional: true},
+				},
+			}), []interface{}{
+				map[string]interface{}{
+					"name":  "--disable-web-security",
+					"value": "",
+				},
+			}),
+			"cookies":        schema.NewSet(schema.HashString, nil),
+			"headers":        schema.NewSet(schema.HashString, nil),
+			"host_overrides": schema.NewSet(schema.HashString, nil),
+			"excluded_files": schema.NewSet(schema.HashString, nil),
+		},
+	})
+
+	got, err := buildAdvancedSettingsData(settings)
+	if err != nil {
+		t.Fatalf("buildAdvancedSettingsData() error = %v", err)
+	}
+	if len(got.ChromeFlags) != 1 {
+		t.Fatalf("ChromeFlags = %#v, want 1 flag", got.ChromeFlags)
+	}
+
+	body, err := json.Marshal(got.ChromeFlags[0])
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	if strings.Contains(string(body), `"value":""`) {
+		t.Fatalf("chrome flag JSON = %s, want the valueless flag to be distinct from an empty-string value", string(body))
+	}
+}
+
+// A Chrome flag with a real value must keep round-tripping unchanged: build
+// maps a non-empty HCL value to a non-nil pointer, and flatten reads it back
+// as the same string.
+func TestChromeFlagsRoundTripPreservesValue(t *testing.T) {
+	settings := schema.NewSet(schema.HashResource(browserCheckV2AdvancedSettingsResource(false)), []interface{}{
+		map[string]interface{}{
+			"user_agent":                  "",
+			"verify_certificates":         true,
+			"collect_interactive_metrics": false,
+			"authentication":              schema.NewSet(schema.HashString, nil),
+			"chrome_flags": schema.NewSet(schema.HashResource(&schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name":  {Type: schema.TypeString, Optional: true},
+					"value": {Type: schema.TypeString, Optional: true},
+				},
+			}), []interface{}{
+				map[string]interface{}{
+					"name":  "--proxy-bypass-list",
+					"value": "127.0.0.1:8080",
+				},
+			}),
+			"cookies":        schema.NewSet(schema.HashString, nil),
+			"headers":        schema.NewSet(schema.HashString, nil),
+			"host_overrides": schema.NewSet(schema.HashString, nil),
+			"excluded_files": schema.NewSet(schema.HashString, nil),
+		},
+	})
+
+	got, err := buildAdvancedSettingsData(settings)
+	if err != nil {
+		t.Fatalf("buildAdvancedSettingsData() error = %v", err)
+	}
+	if len(got.ChromeFlags) != 1 {
+		t.Fatalf("ChromeFlags = %#v, want 1 flag", got.ChromeFlags)
+	}
+	if got.ChromeFlags[0].Value == nil || *got.ChromeFlags[0].Value != "127.0.0.1:8080" {
+		t.Fatalf("ChromeFlags[0].Value = %#v, want \"127.0.0.1:8080\"", got.ChromeFlags[0].Value)
+	}
+
+	flattened := flattenChromeFlagsData(got.ChromeFlags)
+	if len(flattened) != 1 {
+		t.Fatalf("flattenChromeFlagsData() = %#v, want 1 flag", flattened)
+	}
+	flag := flattened[0].(map[string]interface{})
+	if flag["name"] != "--proxy-bypass-list" || flag["value"] != "127.0.0.1:8080" {
+		t.Fatalf("flattened flag = %#v, want name/value preserved", flag)
+	}
+}
+
 func httpV2ResourceDataForPortTest(t *testing.T, includePort bool, port int) *schema.ResourceData {
 	t.Helper()
 

--- a/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/common_models.go
+++ b/vendor/github.com/splunk/syntheticsclient/v2/syntheticsclientv2/common_models.go
@@ -110,8 +110,8 @@ type Advancedsettings struct {
 }
 
 type ChromeFlag struct {
-	Name  string `json:"name"`
-	Value string `json:"value"`
+	Name  string  `json:"name"`
+	Value *string `json:"value,omitempty"`
 }
 
 type ChromeFlagsResponse struct {
@@ -715,7 +715,7 @@ type HttpCheckV2Input struct {
 		UserAgent          *string            `json:"userAgent"`
 		Verifycertificates bool               `json:"verifyCertificates"`
 		CertificateID      *NullableInt       `json:"certificateId,omitempty"`
-		HttpHeaders        []HttpHeaders      `json:"headers,omitempty"`
+		HttpHeaders        *[]HttpHeaders     `json:"headers,omitempty"`
 		Validations        []Validations      `json:"validations"`
 		Customproperties   []CustomProperties `json:"customProperties"`
 		Automaticretries   int                `json:"automaticRetries"`
@@ -768,7 +768,7 @@ type HttpCheckV2InputWithNullablePort struct {
 		UserAgent          *string            `json:"userAgent"`
 		Verifycertificates bool               `json:"verifyCertificates"`
 		CertificateID      *NullableInt       `json:"certificateId,omitempty"`
-		HttpHeaders        []HttpHeaders      `json:"headers,omitempty"`
+		HttpHeaders        *[]HttpHeaders     `json:"headers,omitempty"`
 		Validations        []Validations      `json:"validations"`
 		Customproperties   []CustomProperties `json:"customProperties"`
 		Automaticretries   int                `json:"automaticRetries"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -175,7 +175,7 @@ github.com/oklog/run
 # github.com/splunk/syntheticsclient v1.0.3
 ## explicit; go 1.14
 github.com/splunk/syntheticsclient/syntheticsclient
-# github.com/splunk/syntheticsclient/v2 v2.7.0
+# github.com/splunk/syntheticsclient/v2 v2.7.1-0.20260804043817-13fce789c3b0
 ## explicit; go 1.16
 github.com/splunk/syntheticsclient/v2/syntheticsclientv2
 # github.com/vmihailenco/msgpack v4.0.4+incompatible

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -175,7 +175,7 @@ github.com/oklog/run
 # github.com/splunk/syntheticsclient v1.0.3
 ## explicit; go 1.14
 github.com/splunk/syntheticsclient/syntheticsclient
-# github.com/splunk/syntheticsclient/v2 v2.7.1-0.20260804043817-13fce789c3b0
+# github.com/splunk/syntheticsclient/v2 v2.8.0
 ## explicit; go 1.16
 github.com/splunk/syntheticsclient/v2/syntheticsclientv2
 # github.com/vmihailenco/msgpack v4.0.4+incompatible


### PR DESCRIPTION
## Summary

Fixes two confirmed defects tracked in [SYN-6879](https://splunk.atlassian.net/browse/SYN-6879):

- **[GitHub #73](https://github.com/splunk/terraform-provider-synthetics/issues/73) — HTTP check headers cannot be removed.** Clearing all `headers` blocks from a `synthetics_create_http_check_v2` config never reached the API: the update body's `headers` field was empty and got dropped by `omitempty`, so Terraform could never actually converge state (existing headers stuck around server-side).
- **[GitHub #82](https://github.com/splunk/terraform-provider-synthetics/issues/82) — valueless Chrome flags unsupported.** A `chrome_flags` block with no `value` (e.g. `--disable-web-security`) always serialized `"value":""`, indistinguishable from a flag that legitimately carries an empty string.

Both fixes originate in [splunk/syntheticsclient#50](https://github.com/splunk/syntheticsclient/pull/50), now merged and released as [`v2.8.0`](https://github.com/splunk/syntheticsclient/releases/tag/v2.8.0). This PR bumps `go.mod` to that real tagged release (no more interim pin) and builds the provider-side fix on top of it.

**Note on versioning:** the `v2.8.0` release notes call out that this changes exported Go input field types (`HttpCheckV2Input.Test.HttpHeaders`, `HttpCheckV2InputWithNullablePort.Test.HttpHeaders`, `ChromeFlag.Value`) — a source-breaking change for any direct consumer of those fields. The team made a deliberate call to ship this as a `v2` minor bump rather than a `v3` major bump, since the only known consumer is this provider and the fix here already accounts for the type change.

## Changes

### Library (`github.com/splunk/syntheticsclient/v2 v2.8.0`)
- `ChromeFlag.Value` changed from `string` to `*string` with `json:"value,omitempty"` — nil pointer omits the key entirely (valueless flag); non-nil sends the value.
- `HttpCheckV2Input.Test.HttpHeaders` / `HttpCheckV2InputWithNullablePort.Test.HttpHeaders` changed from `[]HttpHeaders` to `*[]HttpHeaders` (still `json:"headers,omitempty"`) — this three-state pointer-to-slice preserves the distinction between "caller never touched headers" (nil → field omitted, existing headers untouched), "caller explicitly cleared headers" (pointer to empty slice → `"headers":[]`, API clears them), and "caller set headers" (pointer to populated slice → normal array). A plain `[]HttpHeaders` without `omitempty` was tried first but a reviewer on syntheticsclient#50 caught that it would send `"headers":null` for any caller that never touches the field — see [the review thread](https://github.com/splunk/syntheticsclient/pull/50#discussion_r3709002968) for the fix.

### Provider (`synthetics/structures.go`)
- `buildHttpHeadersData` returns `*[]sc2.HttpHeaders` to match the new library type.
- `buildChromeFlagsData` maps an empty-string HCL `value` to a nil pointer (valueless), any non-empty string to `&v`.
- `flattenChromeFlagsData` maps a nil `Value` back to `""` in state, so `value=""` in HCL round-trips with a nil-pointer flag on the wire.

### Tests
- Unit: `TestBuildHttpV2DataEmitsExplicitEmptyHeadersOnRemoval`, `TestChromeFlagsSupportValuelessFlags` (both reproduce the original bugs and now pass), plus `TestChromeFlagsRoundTripPreservesValue` and unset/omitted-header coverage.
- Acceptance (`resource_http_check_v2_test.go`): added steps that remove one of two headers, then remove all remaining headers, asserting `headers.#` converges correctly at each step.
- Acceptance (`resource_browser_check_v2_test.go`): added a step with a valueless `chrome_flags { name = "--disable-web-security" }` block alongside a flag that still carries a value, asserting both round-trip correctly.

### Docs & examples
- Added a `chrome_flags` example to `examples/resources/synthetics_create_browser_check_v2/resource.tf` (none existed before), showing both a valueless flag and a name/value flag.
- Hand-edited `docs/resources/create_browser_check_v2.md`'s `chrome_flags` nested schema to document that `value` may be omitted for valueless flags.

## Validation

- `go build ./...`, `go vet ./...`, `gofmt -l` — all clean against the real `v2.8.0` release.
- `go test ./synthetics/...` — full unit suite passes, no regressions.
- **Full live acceptance suite** (`make testacc`, `TF_ACC=1`, real Synthetics API — same command CI's `integration-test` workflow runs): all 20 `TestAcc*` top-level tests (plus subtests) **PASS**, 0 FAIL. 2 `SKIP` (`TestAccBrowserCheckBasic`, `TestAccHttpCheckBasic`) are pre-existing, unconditional skips for deprecated legacy Rigor V1 resources — unrelated to this change.
  - `TestAccCreateUpdateHttpCheckV2` (7.63s) — includes the new steps that remove one header, then all headers, and asserts the API actually clears them.
  - `TestAccCreateUpdateBrowserCheckV2` (9.95s) — includes the new valueless-Chrome-flag step, asserting it round-trips alongside a flag that still carries a value.
  - No regressions in any of the other 18 live suites (SSL/CA/client-certificate checks, downtime configs, TOTP variables, port checks, browser wait-for-nav/max-wait-time variants, etc.).

## Backward compatibility

- Go API (source): the library's exported field types changed (see versioning note above) — a source-breaking change at the library level, intentionally released as a `v2` minor bump. The provider itself has no public Go API impact; only internal helper signatures changed.
- Wire compatibility: existing configs that set headers/chrome flags with real values are unaffected. The only behavior change is the previously-broken cases: clearing all headers now actually clears them server-side, and a valueless Chrome flag no longer sends a spurious empty string.

## Out of scope
- GitHub #35 (browser-step JSON config) — tracked separately.
- Legacy Rigor-only resources.
