### PR TITLE
SYN-6875: add live acceptance coverage for untested Synthetics V2 data sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# Acceptance test log written by `make testacc`
+testacc.jsonl
+
 # Dependency directories (remove the comment below to include it)
 # vendor/
 

--- a/synthetics/data_source_apicheck_v2_test.go
+++ b/synthetics/data_source_apicheck_v2_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package synthetics
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// The api check resource's `test` block is a TypeSet, which HCL cannot index, so the
+// data source reads back the top-level resource id via tonumber() instead of
+// test[0].id.
+func testAccDataSourceApiCheckV2Config(name string) string {
+	return fmt.Sprintf(`
+resource "synthetics_create_api_check_v2" "api_v2_datasource_fixture" {
+  provider = synthetics.synthetics
+  test {
+    active              = true
+    device_id           = 1
+    frequency           = 5
+    location_ids        = ["aws-us-east-1"]
+    name                = %[1]q
+    scheduling_strategy = "round_robin"
+    automatic_retries   = 1
+
+    requests {
+      configuration {
+        name           = "Get products"
+        request_method = "GET"
+        url            = "https://dummyjson.com/products"
+      }
+    }
+  }
+}
+
+data "synthetics_api_v2_check" "api_v2_datasource" {
+  provider   = synthetics.synthetics
+  depends_on = [synthetics_create_api_check_v2.api_v2_datasource_fixture]
+
+  test {
+    id = tonumber(synthetics_create_api_check_v2.api_v2_datasource_fixture.id)
+  }
+}
+`, name)
+}
+
+func TestAccDataSourceApiCheckV2(t *testing.T) {
+	name := testAccUniqueName("acceptance-terraform-api-v2-datasource")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testAccDataSourceApiCheckV2Config(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"data.synthetics_api_v2_check.api_v2_datasource", "id",
+						"synthetics_create_api_check_v2.api_v2_datasource_fixture", "id",
+					),
+					resource.TestCheckResourceAttr("data.synthetics_api_v2_check.api_v2_datasource", "test.#", "1"),
+					resource.TestCheckResourceAttr("data.synthetics_api_v2_check.api_v2_datasource", "test.0.name", name),
+					resource.TestCheckResourceAttr("data.synthetics_api_v2_check.api_v2_datasource", "test.0.active", "true"),
+					resource.TestCheckResourceAttr("data.synthetics_api_v2_check.api_v2_datasource", "test.0.frequency", "5"),
+					resource.TestCheckResourceAttr("data.synthetics_api_v2_check.api_v2_datasource", "test.0.scheduling_strategy", "round_robin"),
+					resource.TestCheckResourceAttr("data.synthetics_api_v2_check.api_v2_datasource", "test.0.location_ids.0", "aws-us-east-1"),
+					resource.TestCheckResourceAttrSet("data.synthetics_api_v2_check.api_v2_datasource", "test.0.type"),
+				),
+			},
+		},
+	})
+}

--- a/synthetics/data_source_apicheck_v2_test.go
+++ b/synthetics/data_source_apicheck_v2_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	sc2 "github.com/splunk/syntheticsclient/v2/syntheticsclientv2"
 )
 
 // The api check resource's `test` block is a TypeSet, which HCL cannot index, so the
@@ -64,6 +65,12 @@ func TestAccDataSourceApiCheckV2(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
+		CheckDestroy: testAccCheckFixturesDestroyed(map[string]func(string) (*sc2.RequestDetails, error){
+			"synthetics_create_api_check_v2": testAccIntLookup(func(id int) (*sc2.RequestDetails, error) {
+				_, details, err := testAccProvider.Meta().(*sc2.Client).GetApiCheckV2(id)
+				return details, err
+			}),
+		}),
 		Steps: []resource.TestStep{
 			{
 				Config: providerConfig + testAccDataSourceApiCheckV2Config(name),

--- a/synthetics/data_source_apicheck_v2_test.go
+++ b/synthetics/data_source_apicheck_v2_test.go
@@ -24,7 +24,8 @@ import (
 
 // The api check resource's `test` block is a TypeSet, which HCL cannot index, so the
 // data source reads back the top-level resource id via tonumber() instead of
-// test[0].id.
+// test[0].id. See data_source_v2_acc_test.go for why the assertions below can still
+// index the set as test.0.*.
 func testAccDataSourceApiCheckV2Config(name string) string {
 	return fmt.Sprintf(`
 resource "synthetics_create_api_check_v2" "api_v2_datasource_fixture" {

--- a/synthetics/data_source_browsercheck_v2_test.go
+++ b/synthetics/data_source_browsercheck_v2_test.go
@@ -24,6 +24,7 @@ import (
 
 // The top-level resource id is used rather than test[0].id: the block is a TypeSet on
 // most check resources and HCL cannot index a set, so this keeps one idiom throughout.
+// See data_source_v2_acc_test.go for why the assertions below can still index the set.
 func testAccDataSourceBrowserCheckV2Config(name string) string {
 	return fmt.Sprintf(`
 resource "synthetics_create_browser_check_v2" "browser_v2_datasource_fixture" {

--- a/synthetics/data_source_browsercheck_v2_test.go
+++ b/synthetics/data_source_browsercheck_v2_test.go
@@ -1,0 +1,95 @@
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package synthetics
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// The top-level resource id is used rather than test[0].id: the block is a TypeSet on
+// most check resources and HCL cannot index a set, so this keeps one idiom throughout.
+func testAccDataSourceBrowserCheckV2Config(name string) string {
+	return fmt.Sprintf(`
+resource "synthetics_create_browser_check_v2" "browser_v2_datasource_fixture" {
+  provider = synthetics.synthetics
+  test {
+    active              = true
+    device_id           = 1
+    frequency           = 5
+    location_ids        = ["aws-us-east-1"]
+    name                = %[1]q
+    scheduling_strategy = "round_robin"
+    automatic_retries   = 1
+
+    advanced_settings {
+      verify_certificates         = true
+      collect_interactive_metrics = false
+    }
+
+    transactions {
+      name = "First Synthetic transaction"
+
+      steps {
+        name = "01 Go to URL"
+        type = "go_to_url"
+        url  = "https://www.splunk.com"
+      }
+    }
+  }
+}
+
+data "synthetics_browser_v2_check" "browser_v2_datasource" {
+  provider   = synthetics.synthetics
+  depends_on = [synthetics_create_browser_check_v2.browser_v2_datasource_fixture]
+
+  test {
+    id = tonumber(synthetics_create_browser_check_v2.browser_v2_datasource_fixture.id)
+  }
+}
+`, name)
+}
+
+func TestAccDataSourceBrowserCheckV2(t *testing.T) {
+	name := testAccUniqueName("acceptance-terraform-browser-v2-datasource")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testAccDataSourceBrowserCheckV2Config(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"data.synthetics_browser_v2_check.browser_v2_datasource", "id",
+						"synthetics_create_browser_check_v2.browser_v2_datasource_fixture", "id",
+					),
+					resource.TestCheckResourceAttr("data.synthetics_browser_v2_check.browser_v2_datasource", "test.#", "1"),
+					resource.TestCheckResourceAttr("data.synthetics_browser_v2_check.browser_v2_datasource", "test.0.name", name),
+					resource.TestCheckResourceAttr("data.synthetics_browser_v2_check.browser_v2_datasource", "test.0.active", "true"),
+					resource.TestCheckResourceAttr("data.synthetics_browser_v2_check.browser_v2_datasource", "test.0.frequency", "5"),
+					resource.TestCheckResourceAttr("data.synthetics_browser_v2_check.browser_v2_datasource", "test.0.scheduling_strategy", "round_robin"),
+					resource.TestCheckResourceAttrSet("data.synthetics_browser_v2_check.browser_v2_datasource", "test.0.type"),
+					testAccCheckDataSourceListContains(
+						"data.synthetics_browser_v2_check.browser_v2_datasource",
+						"test.0.transactions", "name", "First Synthetic transaction",
+					),
+				),
+			},
+		},
+	})
+}

--- a/synthetics/data_source_browsercheck_v2_test.go
+++ b/synthetics/data_source_browsercheck_v2_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	sc2 "github.com/splunk/syntheticsclient/v2/syntheticsclientv2"
 )
 
 // The top-level resource id is used rather than test[0].id: the block is a TypeSet on
@@ -70,6 +71,12 @@ func TestAccDataSourceBrowserCheckV2(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
+		CheckDestroy: testAccCheckFixturesDestroyed(map[string]func(string) (*sc2.RequestDetails, error){
+			"synthetics_create_browser_check_v2": testAccIntLookup(func(id int) (*sc2.RequestDetails, error) {
+				_, details, err := testAccProvider.Meta().(*sc2.Client).GetBrowserCheckV2(id)
+				return details, err
+			}),
+		}),
 		Steps: []resource.TestStep{
 			{
 				Config: providerConfig + testAccDataSourceBrowserCheckV2Config(name),

--- a/synthetics/data_source_cacertificate_v2_test.go
+++ b/synthetics/data_source_cacertificate_v2_test.go
@@ -1,0 +1,86 @@
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package synthetics
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// Reuses acceptanceCaCertificateContent from resource_ca_certificate_v2_test.go rather
+// than minting new CA material.
+func testAccDataSourceCaCertificateV2Config(name string) string {
+	return fmt.Sprintf(`
+resource "synthetics_create_ca_certificate_v2" "ca_certificate_v2_datasource_fixture" {
+  provider = synthetics.synthetics
+  ca_certificate {
+    name           = %[1]q
+    description    = "Terraform acceptance CA certificate data source fixture"
+    content        = %[2]q
+    file_extension = "pem"
+    filename       = "terraform-ca-datasource.pem"
+  }
+}
+
+data "synthetics_ca_certificate_v2_check" "ca_certificate_v2_datasource" {
+  provider   = synthetics.synthetics
+  depends_on = [synthetics_create_ca_certificate_v2.ca_certificate_v2_datasource_fixture]
+
+  ca_certificate {
+    id = tonumber(synthetics_create_ca_certificate_v2.ca_certificate_v2_datasource_fixture.id)
+  }
+}
+
+data "synthetics_ca_certificates_v2_check" "ca_certificates_v2_datasource" {
+  provider   = synthetics.synthetics
+  depends_on = [synthetics_create_ca_certificate_v2.ca_certificate_v2_datasource_fixture]
+}
+`, name, acceptanceCaCertificateContent)
+}
+
+func TestAccDataSourceCaCertificateV2(t *testing.T) {
+	name := testAccUniqueName("acceptance-terraform-ca-certificate-v2-datasource")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testAccDataSourceCaCertificateV2Config(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Singleton read.
+					resource.TestCheckResourceAttrPair(
+						"data.synthetics_ca_certificate_v2_check.ca_certificate_v2_datasource", "id",
+						"synthetics_create_ca_certificate_v2.ca_certificate_v2_datasource_fixture", "id",
+					),
+					resource.TestCheckResourceAttr("data.synthetics_ca_certificate_v2_check.ca_certificate_v2_datasource", "ca_certificate.#", "1"),
+					resource.TestCheckResourceAttr("data.synthetics_ca_certificate_v2_check.ca_certificate_v2_datasource", "ca_certificate.0.name", name),
+					resource.TestCheckResourceAttr("data.synthetics_ca_certificate_v2_check.ca_certificate_v2_datasource", "ca_certificate.0.description", "Terraform acceptance CA certificate data source fixture"),
+					resource.TestCheckResourceAttr("data.synthetics_ca_certificate_v2_check.ca_certificate_v2_datasource", "ca_certificate.0.file_extension", "pem"),
+					resource.TestCheckResourceAttr("data.synthetics_ca_certificate_v2_check.ca_certificate_v2_datasource", "ca_certificate.0.filename", "terraform-ca-datasource.pem"),
+
+					// List read must contain the fixture. Asserted by name, never by content.
+					resource.TestCheckResourceAttrSet("data.synthetics_ca_certificates_v2_check.ca_certificates_v2_datasource", "id"),
+					testAccCheckDataSourceListContains(
+						"data.synthetics_ca_certificates_v2_check.ca_certificates_v2_datasource",
+						"ca_certificates", "name", name,
+					),
+				),
+			},
+		},
+	})
+}

--- a/synthetics/data_source_cacertificate_v2_test.go
+++ b/synthetics/data_source_cacertificate_v2_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	sc2 "github.com/splunk/syntheticsclient/v2/syntheticsclientv2"
 )
 
 // Reuses acceptanceCaCertificateContent from resource_ca_certificate_v2_test.go rather
@@ -58,6 +59,12 @@ func TestAccDataSourceCaCertificateV2(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
+		CheckDestroy: testAccCheckFixturesDestroyed(map[string]func(string) (*sc2.RequestDetails, error){
+			"synthetics_create_ca_certificate_v2": testAccIntLookup(func(id int) (*sc2.RequestDetails, error) {
+				_, details, err := testAccProvider.Meta().(*sc2.Client).GetCaCertificateV2(id)
+				return details, err
+			}),
+		}),
 		Steps: []resource.TestStep{
 			{
 				Config: providerConfig + testAccDataSourceCaCertificateV2Config(name),

--- a/synthetics/data_source_client_certificate_v2_test.go
+++ b/synthetics/data_source_client_certificate_v2_test.go
@@ -64,8 +64,9 @@ data "synthetics_client_certificates_v2_check" "all" {
 `
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckClientCertificateV2Destroy,
 		Steps: []resource.TestStep{
 			{
 				Config: providerConfig + config,

--- a/synthetics/data_source_client_certificate_v2_test.go
+++ b/synthetics/data_source_client_certificate_v2_test.go
@@ -14,7 +14,11 @@
 
 package synthetics
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
 
 func TestClientCertificateV2DataSourceIsMetadataOnly(t *testing.T) {
 	dataSource := dataSourceClientCertificateV2()
@@ -30,4 +34,68 @@ func TestClientCertificateV2DataSourceIsMetadataOnly(t *testing.T) {
 	if _, ok := dataSource.Schema["private_key"]; ok {
 		t.Fatal("client certificate data source must not expose private_key")
 	}
+}
+
+// The client certificate data sources are metadata-only by design: the API returns
+// certificate and private key material redacted. These assertions cover the metadata
+// fields and positively assert that no key material reaches state. No assertion or
+// failure message here interpolates certificate or key content.
+func TestAccDataSourceClientCertificateV2(t *testing.T) {
+	name := testAccUniqueName("terraform-client-cert-datasource")
+	publicKey, privateKey := testAccClientCertificateV2Material(t)
+
+	config := testAccClientCertificateV2Config(
+		name,
+		"Terraform acceptance client certificate data source fixture",
+		"client.crt", "client.key",
+		publicKey, privateKey,
+	) + `
+data "synthetics_client_certificate_v2_check" "mtls" {
+  provider   = synthetics.synthetics
+  depends_on = [synthetics_create_client_certificate_v2.mtls]
+
+  id = tonumber(synthetics_create_client_certificate_v2.mtls.id)
+}
+
+data "synthetics_client_certificates_v2_check" "all" {
+  provider   = synthetics.synthetics
+  depends_on = [synthetics_create_client_certificate_v2.mtls]
+}
+`
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + config,
+				Check: resource.ComposeTestCheckFunc(
+					// Singleton read: metadata only.
+					resource.TestCheckResourceAttrPair(
+						"data.synthetics_client_certificate_v2_check.mtls", "id",
+						"synthetics_create_client_certificate_v2.mtls", "id",
+					),
+					resource.TestCheckResourceAttr("data.synthetics_client_certificate_v2_check.mtls", "name", name),
+					resource.TestCheckResourceAttr("data.synthetics_client_certificate_v2_check.mtls", "description", "Terraform acceptance client certificate data source fixture"),
+					resource.TestCheckResourceAttr("data.synthetics_client_certificate_v2_check.mtls", "domain", "api.example.com"),
+					resource.TestCheckResourceAttrSet("data.synthetics_client_certificate_v2_check.mtls", "expires_at"),
+					testAccCheckDataSourceAttrsAbsent(
+						"data.synthetics_client_certificate_v2_check.mtls",
+						"public_key", "private_key", "content", "password",
+					),
+
+					// List read must contain the fixture, still metadata only.
+					resource.TestCheckResourceAttrSet("data.synthetics_client_certificates_v2_check.all", "id"),
+					testAccCheckDataSourceListContains(
+						"data.synthetics_client_certificates_v2_check.all",
+						"client_certificates", "name", name,
+					),
+					testAccCheckDataSourceAttrsAbsent(
+						"data.synthetics_client_certificates_v2_check.all",
+						"public_key", "private_key", "content", "password",
+					),
+				),
+			},
+		},
+	})
 }

--- a/synthetics/data_source_devices_v2_test.go
+++ b/synthetics/data_source_devices_v2_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package synthetics
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// The device catalog is account-global and cannot be created by Terraform, so there is no
+// fixture to look for. Assertions are limited to stable representative shape: the
+// collection is non-empty and some element carries every field the flattener populates.
+const testAccDataSourceDevicesV2Config = `
+data "synthetics_devices_v2_check" "devices_v2_datasource" {
+  provider = synthetics.synthetics
+}
+`
+
+func TestAccDataSourceDevicesV2(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testAccDataSourceDevicesV2Config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.synthetics_devices_v2_check.devices_v2_datasource", "id", "global_devices_synthetics"),
+					testAccCheckDataSourceCollectionNotEmpty(
+						"data.synthetics_devices_v2_check.devices_v2_datasource", "devices",
+					),
+					testAccCheckDataSourceElemFieldsNonEmpty(
+						"data.synthetics_devices_v2_check.devices_v2_datasource",
+						"devices", "id", "label", "user_agent", "viewport_height", "viewport_width",
+					),
+				),
+			},
+		},
+	})
+}

--- a/synthetics/data_source_downtimeconfiguration_v2_test.go
+++ b/synthetics/data_source_downtimeconfiguration_v2_test.go
@@ -1,0 +1,106 @@
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package synthetics
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// A downtime configuration requires start_time in the future and test_ids that exist in
+// the org, so a disposable port check is created alongside it and referenced by generated
+// id — the same shape as testAccDowntimeConfigurationV2Config.
+func testAccDataSourceDowntimeConfigurationV2Config(name, startTime, endTime string) string {
+	return fmt.Sprintf(`
+resource "synthetics_create_port_check_v2" "downtime_v2_datasource_test_fixture" {
+  provider = synthetics.synthetics
+  test {
+    active              = true
+    frequency           = 5
+    location_ids        = ["aws-us-west-2"]
+    scheduling_strategy = "round_robin"
+    name                = "%[1]s-test-fixture"
+    port                = 8081
+    protocol            = "tcp"
+    host                = "www.splunk.com"
+  }
+}
+
+resource "synthetics_create_downtime_configuration_v2" "downtime_configuration_v2_datasource_fixture" {
+  provider = synthetics.synthetics
+  downtime_configuration {
+    name        = "%[1]s"
+    description = "Terraform acceptance downtime configuration data source fixture"
+    rule        = "augment_data"
+    start_time  = "%[2]s"
+    end_time    = "%[3]s"
+    test_ids    = [tonumber(synthetics_create_port_check_v2.downtime_v2_datasource_test_fixture.id)]
+  }
+}
+
+data "synthetics_downtime_configuration_v2_check" "downtime_configuration_v2_datasource" {
+  provider   = synthetics.synthetics
+  depends_on = [synthetics_create_downtime_configuration_v2.downtime_configuration_v2_datasource_fixture]
+
+  downtime_configuration {
+    id = tonumber(synthetics_create_downtime_configuration_v2.downtime_configuration_v2_datasource_fixture.id)
+  }
+}
+
+data "synthetics_downtime_configurations_v2_check" "downtime_configurations_v2_datasource" {
+  provider   = synthetics.synthetics
+  depends_on = [synthetics_create_downtime_configuration_v2.downtime_configuration_v2_datasource_fixture]
+}
+`, name, startTime, endTime)
+}
+
+func TestAccDataSourceDowntimeConfigurationV2(t *testing.T) {
+	name := testAccUniqueName("acceptance-terraform-downtime-configuration-v2-datasource")
+	startTime := time.Now().Add(24 * time.Hour).Format("2006-01-02T15:04:05.000Z")
+	endTime := time.Now().Add(48 * time.Hour).Format("2006-01-02T15:04:05.000Z")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testAccDataSourceDowntimeConfigurationV2Config(name, startTime, endTime),
+				Check: resource.ComposeTestCheckFunc(
+					// Singleton read.
+					resource.TestCheckResourceAttrPair(
+						"data.synthetics_downtime_configuration_v2_check.downtime_configuration_v2_datasource", "id",
+						"synthetics_create_downtime_configuration_v2.downtime_configuration_v2_datasource_fixture", "id",
+					),
+					resource.TestCheckResourceAttr("data.synthetics_downtime_configuration_v2_check.downtime_configuration_v2_datasource", "downtime_configuration.#", "1"),
+					resource.TestCheckResourceAttr("data.synthetics_downtime_configuration_v2_check.downtime_configuration_v2_datasource", "downtime_configuration.0.name", name),
+					resource.TestCheckResourceAttr("data.synthetics_downtime_configuration_v2_check.downtime_configuration_v2_datasource", "downtime_configuration.0.description", "Terraform acceptance downtime configuration data source fixture"),
+					resource.TestCheckResourceAttr("data.synthetics_downtime_configuration_v2_check.downtime_configuration_v2_datasource", "downtime_configuration.0.rule", "augment_data"),
+					resource.TestCheckResourceAttr("data.synthetics_downtime_configuration_v2_check.downtime_configuration_v2_datasource", "downtime_configuration.0.start_time", startTime),
+					resource.TestCheckResourceAttr("data.synthetics_downtime_configuration_v2_check.downtime_configuration_v2_datasource", "downtime_configuration.0.end_time", endTime),
+
+					// List read must contain the fixture.
+					resource.TestCheckResourceAttrSet("data.synthetics_downtime_configurations_v2_check.downtime_configurations_v2_datasource", "id"),
+					testAccCheckDataSourceListContains(
+						"data.synthetics_downtime_configurations_v2_check.downtime_configurations_v2_datasource",
+						"downtime_configurations", "name", name,
+					),
+				),
+			},
+		},
+	})
+}

--- a/synthetics/data_source_downtimeconfiguration_v2_test.go
+++ b/synthetics/data_source_downtimeconfiguration_v2_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	sc2 "github.com/splunk/syntheticsclient/v2/syntheticsclientv2"
 )
 
 // A downtime configuration requires start_time in the future and test_ids that exist in
@@ -77,6 +78,17 @@ func TestAccDataSourceDowntimeConfigurationV2(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
+		// This test creates two fixtures; both must be gone after destroy.
+		CheckDestroy: testAccCheckFixturesDestroyed(map[string]func(string) (*sc2.RequestDetails, error){
+			"synthetics_create_downtime_configuration_v2": testAccIntLookup(func(id int) (*sc2.RequestDetails, error) {
+				_, details, err := testAccProvider.Meta().(*sc2.Client).GetDowntimeConfigurationV2(id)
+				return details, err
+			}),
+			"synthetics_create_port_check_v2": testAccIntLookup(func(id int) (*sc2.RequestDetails, error) {
+				_, details, err := testAccProvider.Meta().(*sc2.Client).GetPortCheckV2(id)
+				return details, err
+			}),
+		}),
 		Steps: []resource.TestStep{
 			{
 				Config: providerConfig + testAccDataSourceDowntimeConfigurationV2Config(name, startTime, endTime),

--- a/synthetics/data_source_httpcheck_v2_test.go
+++ b/synthetics/data_source_httpcheck_v2_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	sc2 "github.com/splunk/syntheticsclient/v2/syntheticsclientv2"
 )
 
 func testAccDataSourceHttpCheckV2Config(name string) string {
@@ -57,6 +58,12 @@ func TestAccDataSourceHttpCheckV2(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
+		CheckDestroy: testAccCheckFixturesDestroyed(map[string]func(string) (*sc2.RequestDetails, error){
+			"synthetics_create_http_check_v2": testAccIntLookup(func(id int) (*sc2.RequestDetails, error) {
+				_, details, err := testAccProvider.Meta().(*sc2.Client).GetHttpCheckV2(id)
+				return details, err
+			}),
+		}),
 		Steps: []resource.TestStep{
 			{
 				Config: providerConfig + testAccDataSourceHttpCheckV2Config(name),

--- a/synthetics/data_source_httpcheck_v2_test.go
+++ b/synthetics/data_source_httpcheck_v2_test.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package synthetics
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func testAccDataSourceHttpCheckV2Config(name string) string {
+	return fmt.Sprintf(`
+resource "synthetics_create_http_check_v2" "http_v2_datasource_fixture" {
+  provider = synthetics.synthetics
+  test {
+    active              = true
+    frequency           = 5
+    location_ids        = ["aws-us-east-1"]
+    name                = %[1]q
+    type                = "http"
+    url                 = "https://www.splunk.com"
+    port                = 443
+    request_method      = "GET"
+    verify_certificates = true
+    scheduling_strategy = "round_robin"
+    automatic_retries   = 1
+  }
+}
+
+data "synthetics_http_v2_check" "http_v2_datasource" {
+  provider   = synthetics.synthetics
+  depends_on = [synthetics_create_http_check_v2.http_v2_datasource_fixture]
+
+  test {
+    id = tonumber(synthetics_create_http_check_v2.http_v2_datasource_fixture.id)
+  }
+}
+`, name)
+}
+
+func TestAccDataSourceHttpCheckV2(t *testing.T) {
+	name := testAccUniqueName("acceptance-terraform-http-v2-datasource")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testAccDataSourceHttpCheckV2Config(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"data.synthetics_http_v2_check.http_v2_datasource", "id",
+						"synthetics_create_http_check_v2.http_v2_datasource_fixture", "id",
+					),
+					resource.TestCheckResourceAttr("data.synthetics_http_v2_check.http_v2_datasource", "test.#", "1"),
+					resource.TestCheckResourceAttr("data.synthetics_http_v2_check.http_v2_datasource", "test.0.name", name),
+					resource.TestCheckResourceAttr("data.synthetics_http_v2_check.http_v2_datasource", "test.0.active", "true"),
+					resource.TestCheckResourceAttr("data.synthetics_http_v2_check.http_v2_datasource", "test.0.frequency", "5"),
+					resource.TestCheckResourceAttr("data.synthetics_http_v2_check.http_v2_datasource", "test.0.url", "https://www.splunk.com"),
+					resource.TestCheckResourceAttr("data.synthetics_http_v2_check.http_v2_datasource", "test.0.port", "443"),
+					resource.TestCheckResourceAttr("data.synthetics_http_v2_check.http_v2_datasource", "test.0.scheduling_strategy", "round_robin"),
+					resource.TestCheckResourceAttrSet("data.synthetics_http_v2_check.http_v2_datasource", "test.0.type"),
+				),
+			},
+		},
+	})
+}

--- a/synthetics/data_source_location_v2_test.go
+++ b/synthetics/data_source_location_v2_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	sc2 "github.com/splunk/syntheticsclient/v2/syntheticsclientv2"
 )
 
 // A disposable private location is used for the singleton read so the test does not
@@ -58,6 +59,13 @@ func TestAccDataSourceLocationV2(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
+		// Location ids are strings, so this lookup is not wrapped in testAccIntLookup.
+		CheckDestroy: testAccCheckFixturesDestroyed(map[string]func(string) (*sc2.RequestDetails, error){
+			"synthetics_create_location_v2": func(id string) (*sc2.RequestDetails, error) {
+				_, details, err := testAccProvider.Meta().(*sc2.Client).GetLocationV2(id)
+				return details, err
+			},
+		}),
 		Steps: []resource.TestStep{
 			{
 				Config: providerConfig + testAccDataSourceLocationV2Config(id, label),

--- a/synthetics/data_source_location_v2_test.go
+++ b/synthetics/data_source_location_v2_test.go
@@ -1,0 +1,91 @@
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package synthetics
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// A disposable private location is used for the singleton read so the test does not
+// depend on any particular public location existing in the org. Location ids are
+// validated against privateLocationIDPattern, which forbids digits, so the id comes
+// from testAccUniquePrivateLocationID rather than a numeric suffix.
+func testAccDataSourceLocationV2Config(id, label string) string {
+	return fmt.Sprintf(`
+resource "synthetics_create_location_v2" "location_v2_datasource_fixture" {
+  provider = synthetics.synthetics
+  location {
+    id    = %[1]q
+    label = %[2]q
+  }
+}
+
+data "synthetics_location_v2_check" "location_v2_datasource" {
+  provider   = synthetics.synthetics
+  depends_on = [synthetics_create_location_v2.location_v2_datasource_fixture]
+
+  location {
+    id = synthetics_create_location_v2.location_v2_datasource_fixture.id
+  }
+}
+
+data "synthetics_locations_v2_check" "locations_v2_datasource" {
+  provider   = synthetics.synthetics
+  depends_on = [synthetics_create_location_v2.location_v2_datasource_fixture]
+}
+`, id, label)
+}
+
+func TestAccDataSourceLocationV2(t *testing.T) {
+	id := testAccUniquePrivateLocationID("acc-datasource")
+	label := "Terraform acceptance location data source fixture"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testAccDataSourceLocationV2Config(id, label),
+				Check: resource.ComposeTestCheckFunc(
+					// Singleton read of the disposable private location.
+					resource.TestCheckResourceAttrPair(
+						"data.synthetics_location_v2_check.location_v2_datasource", "id",
+						"synthetics_create_location_v2.location_v2_datasource_fixture", "id",
+					),
+					resource.TestCheckResourceAttr("data.synthetics_location_v2_check.location_v2_datasource", "location.#", "1"),
+					resource.TestCheckResourceAttr("data.synthetics_location_v2_check.location_v2_datasource", "location.0.id", id),
+					resource.TestCheckResourceAttr("data.synthetics_location_v2_check.location_v2_datasource", "location.0.label", label),
+					resource.TestCheckResourceAttrSet("data.synthetics_location_v2_check.location_v2_datasource", "location.0.type"),
+
+					// List read: the fixture must appear, and the account-global fields
+					// are asserted only for stable non-empty shape.
+					resource.TestCheckResourceAttrSet("data.synthetics_locations_v2_check.locations_v2_datasource", "id"),
+					testAccCheckDataSourceListContains(
+						"data.synthetics_locations_v2_check.locations_v2_datasource",
+						"locations", "id", id,
+					),
+					testAccCheckDataSourceElemFieldsNonEmpty(
+						"data.synthetics_locations_v2_check.locations_v2_datasource",
+						"locations", "id", "label", "type",
+					),
+					resource.TestCheckResourceAttrSet("data.synthetics_locations_v2_check.locations_v2_datasource", "default_location_ids.#"),
+				),
+			},
+		},
+	})
+}

--- a/synthetics/data_source_portcheck_v2_test.go
+++ b/synthetics/data_source_portcheck_v2_test.go
@@ -1,0 +1,78 @@
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package synthetics
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func testAccDataSourcePortCheckV2Config(name string) string {
+	return fmt.Sprintf(`
+resource "synthetics_create_port_check_v2" "port_v2_datasource_fixture" {
+  provider = synthetics.synthetics
+  test {
+    active              = true
+    frequency           = 5
+    location_ids        = ["aws-us-east-1"]
+    name                = %[1]q
+    host                = "www.splunk.com"
+    port                = 8081
+    protocol            = "tcp"
+    scheduling_strategy = "round_robin"
+    automatic_retries   = 1
+  }
+}
+
+data "synthetics_port_v2_check" "port_v2_datasource" {
+  provider   = synthetics.synthetics
+  depends_on = [synthetics_create_port_check_v2.port_v2_datasource_fixture]
+
+  test {
+    id = tonumber(synthetics_create_port_check_v2.port_v2_datasource_fixture.id)
+  }
+}
+`, name)
+}
+
+func TestAccDataSourcePortCheckV2(t *testing.T) {
+	name := testAccUniqueName("acceptance-terraform-port-v2-datasource")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testAccDataSourcePortCheckV2Config(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"data.synthetics_port_v2_check.port_v2_datasource", "id",
+						"synthetics_create_port_check_v2.port_v2_datasource_fixture", "id",
+					),
+					resource.TestCheckResourceAttr("data.synthetics_port_v2_check.port_v2_datasource", "test.#", "1"),
+					resource.TestCheckResourceAttr("data.synthetics_port_v2_check.port_v2_datasource", "test.0.name", name),
+					resource.TestCheckResourceAttr("data.synthetics_port_v2_check.port_v2_datasource", "test.0.active", "true"),
+					resource.TestCheckResourceAttr("data.synthetics_port_v2_check.port_v2_datasource", "test.0.frequency", "5"),
+					resource.TestCheckResourceAttr("data.synthetics_port_v2_check.port_v2_datasource", "test.0.host", "www.splunk.com"),
+					resource.TestCheckResourceAttr("data.synthetics_port_v2_check.port_v2_datasource", "test.0.port", "8081"),
+					resource.TestCheckResourceAttr("data.synthetics_port_v2_check.port_v2_datasource", "test.0.protocol", "tcp"),
+					resource.TestCheckResourceAttrSet("data.synthetics_port_v2_check.port_v2_datasource", "test.0.type"),
+				),
+			},
+		},
+	})
+}

--- a/synthetics/data_source_portcheck_v2_test.go
+++ b/synthetics/data_source_portcheck_v2_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	sc2 "github.com/splunk/syntheticsclient/v2/syntheticsclientv2"
 )
 
 func testAccDataSourcePortCheckV2Config(name string) string {
@@ -55,6 +56,12 @@ func TestAccDataSourcePortCheckV2(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
+		CheckDestroy: testAccCheckFixturesDestroyed(map[string]func(string) (*sc2.RequestDetails, error){
+			"synthetics_create_port_check_v2": testAccIntLookup(func(id int) (*sc2.RequestDetails, error) {
+				_, details, err := testAccProvider.Meta().(*sc2.Client).GetPortCheckV2(id)
+				return details, err
+			}),
+		}),
 		Steps: []resource.TestStep{
 			{
 				Config: providerConfig + testAccDataSourcePortCheckV2Config(name),

--- a/synthetics/data_source_sslcheck_v2_test.go
+++ b/synthetics/data_source_sslcheck_v2_test.go
@@ -1,0 +1,81 @@
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package synthetics
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func testAccDataSourceSslCheckV2Config(name string) string {
+	return fmt.Sprintf(`
+resource "synthetics_create_ssl_check_v2" "ssl_v2_datasource_fixture" {
+  provider = synthetics.synthetics
+  test {
+    active               = false
+    frequency            = 5
+    location_ids         = ["aws-us-east-1"]
+    name                 = %[1]q
+    host                 = "www.splunk.com"
+    port                 = 443
+    server_name          = "www.splunk.com"
+    allow_self_signed    = false
+    allow_untrusted_root = false
+    scheduling_strategy  = "round_robin"
+    automatic_retries    = 1
+  }
+}
+
+data "synthetics_ssl_v2_check" "ssl_v2_datasource" {
+  provider   = synthetics.synthetics
+  depends_on = [synthetics_create_ssl_check_v2.ssl_v2_datasource_fixture]
+
+  test {
+    id = tonumber(synthetics_create_ssl_check_v2.ssl_v2_datasource_fixture.id)
+  }
+}
+`, name)
+}
+
+func TestAccDataSourceSslCheckV2(t *testing.T) {
+	name := testAccUniqueName("acceptance-terraform-ssl-v2-datasource")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testAccDataSourceSslCheckV2Config(name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"data.synthetics_ssl_v2_check.ssl_v2_datasource", "id",
+						"synthetics_create_ssl_check_v2.ssl_v2_datasource_fixture", "id",
+					),
+					resource.TestCheckResourceAttr("data.synthetics_ssl_v2_check.ssl_v2_datasource", "test.#", "1"),
+					resource.TestCheckResourceAttr("data.synthetics_ssl_v2_check.ssl_v2_datasource", "test.0.name", name),
+					resource.TestCheckResourceAttr("data.synthetics_ssl_v2_check.ssl_v2_datasource", "test.0.active", "false"),
+					resource.TestCheckResourceAttr("data.synthetics_ssl_v2_check.ssl_v2_datasource", "test.0.frequency", "5"),
+					resource.TestCheckResourceAttr("data.synthetics_ssl_v2_check.ssl_v2_datasource", "test.0.host", "www.splunk.com"),
+					resource.TestCheckResourceAttr("data.synthetics_ssl_v2_check.ssl_v2_datasource", "test.0.port", "443"),
+					resource.TestCheckResourceAttr("data.synthetics_ssl_v2_check.ssl_v2_datasource", "test.0.server_name", "www.splunk.com"),
+					resource.TestCheckResourceAttr("data.synthetics_ssl_v2_check.ssl_v2_datasource", "test.0.allow_self_signed", "false"),
+					resource.TestCheckResourceAttrSet("data.synthetics_ssl_v2_check.ssl_v2_datasource", "test.0.type"),
+				),
+			},
+		},
+	})
+}

--- a/synthetics/data_source_sslcheck_v2_test.go
+++ b/synthetics/data_source_sslcheck_v2_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	sc2 "github.com/splunk/syntheticsclient/v2/syntheticsclientv2"
 )
 
 func testAccDataSourceSslCheckV2Config(name string) string {
@@ -57,6 +58,12 @@ func TestAccDataSourceSslCheckV2(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
+		CheckDestroy: testAccCheckFixturesDestroyed(map[string]func(string) (*sc2.RequestDetails, error){
+			"synthetics_create_ssl_check_v2": testAccIntLookup(func(id int) (*sc2.RequestDetails, error) {
+				_, details, err := testAccProvider.Meta().(*sc2.Client).GetSslCheckV2(id)
+				return details, err
+			}),
+		}),
 		Steps: []resource.TestStep{
 			{
 				Config: providerConfig + testAccDataSourceSslCheckV2Config(name),

--- a/synthetics/data_source_v2_acc_test.go
+++ b/synthetics/data_source_v2_acc_test.go
@@ -27,6 +27,20 @@ import (
 	sc2 "github.com/splunk/syntheticsclient/v2/syntheticsclientv2"
 )
 
+// A note on indexing TypeSet blocks in these tests, since the two halves differ:
+//
+//   - In HCL, a TypeSet block cannot be indexed, so a fixture is referenced through the
+//     top-level resource id (`tonumber(resource.id)`) rather than `test[0].id`.
+//   - In assertions, `test.0.name` is correct. helper/schema stores set elements under
+//     hash keys, but acceptance tests do not read that state: the SDK reads Terraform's
+//     JSON state and rebuilds the flatmap through shimStateFromJson, whose AddSlice
+//     numbers every collection sequentially from 0 (state_shim.go). So set elements
+//     arrive as `test.0.*` regardless of their hash.
+//
+// Ordering within a *multi-element* set is still not meaningful, which is why list reads
+// go through testAccCheckDataSourceListContains instead of a fixed index. Singleton reads
+// assert `<block>.#` is 1 first, so index 0 is unambiguous.
+
 // testAccCheckFixturesDestroyed asserts that every fixture the test created is gone from
 // the API after Terraform destroys it. The SDK already fails a test whose destroy errors,
 // but that only proves the provider reported success; this re-reads each id and requires a

--- a/synthetics/data_source_v2_acc_test.go
+++ b/synthetics/data_source_v2_acc_test.go
@@ -16,13 +16,58 @@ package synthetics
 
 import (
 	"fmt"
+	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	sc2 "github.com/splunk/syntheticsclient/v2/syntheticsclientv2"
 )
+
+// testAccCheckFixturesDestroyed asserts that every fixture the test created is gone from
+// the API after Terraform destroys it. The SDK already fails a test whose destroy errors,
+// but that only proves the provider reported success; this re-reads each id and requires a
+// 404, so a Delete that silently no-ops cannot pass.
+//
+// lookups is keyed by resource type. Each lookup receives the raw state id and returns the
+// request details of a get for that id.
+func testAccCheckFixturesDestroyed(lookups map[string]func(id string) (*sc2.RequestDetails, error)) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			lookup, ok := lookups[rs.Type]
+			if !ok {
+				continue
+			}
+
+			details, err := lookup(rs.Primary.ID)
+			if details != nil && details.StatusCode == http.StatusNotFound {
+				continue
+			}
+			if err != nil {
+				return fmt.Errorf("verifying %s %s was destroyed: %w", rs.Type, rs.Primary.ID, err)
+			}
+
+			return fmt.Errorf("%s %s still exists after destroy", rs.Type, rs.Primary.ID)
+		}
+
+		return nil
+	}
+}
+
+// testAccIntLookup adapts a client getter keyed by an integer id to the string-keyed
+// signature testAccCheckFixturesDestroyed expects.
+func testAccIntLookup(get func(id int) (*sc2.RequestDetails, error)) func(string) (*sc2.RequestDetails, error) {
+	return func(id string) (*sc2.RequestDetails, error) {
+		n, err := strconv.Atoi(id)
+		if err != nil {
+			return nil, err
+		}
+		return get(n)
+	}
+}
 
 // testAccUniqueName builds a collision-resistant fixture name so the acceptance
 // suite can be re-run and run in parallel against the same live org.
@@ -160,6 +205,60 @@ func testAccCheckDataSourceElemFieldsNonEmpty(dataSourceName, collection string,
 
 		return fmt.Errorf("%s had no %s element with all of %v set to a non-empty value", dataSourceName, collection, fields)
 	}
+}
+
+// The client reports a missing object as a 404 in RequestDetails *and* a non-nil error,
+// so the status check has to come before the error check. This pins that ordering: a
+// deleted fixture must pass, and a fixture the API still returns must fail.
+func TestCheckFixturesDestroyed(t *testing.T) {
+	state := &terraform.State{
+		Modules: []*terraform.ModuleState{{
+			Path: []string{"root"},
+			Resources: map[string]*terraform.ResourceState{
+				"synthetics_create_variable_v2.fixture": {
+					Type:     "synthetics_create_variable_v2",
+					Primary:  &terraform.InstanceState{ID: "42"},
+					Provider: "provider.synthetics",
+				},
+			},
+		}},
+	}
+
+	lookups := func(details *sc2.RequestDetails, err error) map[string]func(string) (*sc2.RequestDetails, error) {
+		return map[string]func(string) (*sc2.RequestDetails, error){
+			"synthetics_create_variable_v2": func(string) (*sc2.RequestDetails, error) {
+				return details, err
+			},
+		}
+	}
+
+	t.Run("deleted fixture passes even though the client also returns an error", func(t *testing.T) {
+		check := testAccCheckFixturesDestroyed(lookups(&sc2.RequestDetails{StatusCode: http.StatusNotFound}, fmt.Errorf("Status Code: 404 Not Found")))
+		if err := check(state); err != nil {
+			t.Fatalf("expected a destroyed fixture to pass, got: %s", err)
+		}
+	})
+
+	t.Run("surviving fixture fails", func(t *testing.T) {
+		check := testAccCheckFixturesDestroyed(lookups(&sc2.RequestDetails{StatusCode: http.StatusOK}, nil))
+		if err := check(state); err == nil {
+			t.Fatal("expected a fixture that still exists to fail the destroy check")
+		}
+	})
+
+	t.Run("unexpected error fails", func(t *testing.T) {
+		check := testAccCheckFixturesDestroyed(lookups(&sc2.RequestDetails{StatusCode: http.StatusInternalServerError}, fmt.Errorf("boom")))
+		if err := check(state); err == nil {
+			t.Fatal("expected an unexpected lookup error to fail the destroy check")
+		}
+	})
+
+	t.Run("unmapped resource types are ignored", func(t *testing.T) {
+		check := testAccCheckFixturesDestroyed(map[string]func(string) (*sc2.RequestDetails, error){})
+		if err := check(state); err != nil {
+			t.Fatalf("expected unmapped resource types to be skipped, got: %s", err)
+		}
+	})
 }
 
 func TestUniquePrivateLocationIDIsValid(t *testing.T) {

--- a/synthetics/data_source_v2_acc_test.go
+++ b/synthetics/data_source_v2_acc_test.go
@@ -1,0 +1,170 @@
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package synthetics
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+// testAccUniqueName builds a collision-resistant fixture name so the acceptance
+// suite can be re-run and run in parallel against the same live org.
+func testAccUniqueName(prefix string) string {
+	return fmt.Sprintf("%s-%d", prefix, time.Now().UnixNano())
+}
+
+// testAccUniquePrivateLocationID builds a unique private location id. Location ids
+// are validated against `\Aprivate-[a-z\-]*[a-z]\z`, so the usual numeric UnixNano
+// suffix is rejected; the timestamp is encoded as lowercase letters instead.
+func testAccUniquePrivateLocationID(prefix string) string {
+	var suffix strings.Builder
+	for n := time.Now().UnixNano(); n > 0; n /= 26 {
+		suffix.WriteByte(byte('a' + n%26))
+	}
+	return fmt.Sprintf("private-%s-%s", prefix, suffix.String())
+}
+
+// testAccCheckDataSourceListContains asserts that a collection returned by a list
+// data source includes an element whose `field` equals `expected`.
+//
+// These collections are org-wide, so the fixture's position depends on whatever else
+// exists in the account. Matching on any index keeps the assertion about presence
+// rather than ordering.
+func testAccCheckDataSourceListContains(dataSourceName, collection, field, expected string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[dataSourceName]
+		if !ok {
+			return fmt.Errorf("data source %s not found", dataSourceName)
+		}
+
+		if count := rs.Primary.Attributes[collection+".#"]; count == "" || count == "0" {
+			return fmt.Errorf("%s returned no %s entries", dataSourceName, collection)
+		}
+
+		for index := range testAccDataSourceCollectionIndexes(rs.Primary.Attributes, collection) {
+			if rs.Primary.Attributes[fmt.Sprintf("%s.%s.%s", collection, index, field)] == expected {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("%s did not include a %s entry with %s = %q", dataSourceName, collection, field, expected)
+	}
+}
+
+// testAccDataSourceCollectionIndexes returns the element indexes present for a
+// collection in flatmap state, ignoring the `.#` count key and any deeper nesting.
+func testAccDataSourceCollectionIndexes(attributes map[string]string, collection string) map[string]struct{} {
+	indexes := map[string]struct{}{}
+	prefix := collection + "."
+	for key := range attributes {
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		rest := strings.TrimPrefix(key, prefix)
+		if index, _, found := strings.Cut(rest, "."); found {
+			indexes[index] = struct{}{}
+		}
+	}
+	return indexes
+}
+
+// testAccCheckDataSourceAttrsAbsent asserts that none of the given attribute names
+// appear anywhere in a data source's state, at any nesting depth. Used to prove
+// metadata-only data sources never surface certificate or private key material.
+func testAccCheckDataSourceAttrsAbsent(dataSourceName string, fields ...string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[dataSourceName]
+		if !ok {
+			return fmt.Errorf("data source %s not found", dataSourceName)
+		}
+
+		for key := range rs.Primary.Attributes {
+			for _, field := range fields {
+				if key == field || strings.HasSuffix(key, "."+field) {
+					// Deliberately does not log the value.
+					return fmt.Errorf("%s exposed forbidden attribute %s", dataSourceName, key)
+				}
+			}
+		}
+
+		return nil
+	}
+}
+
+// testAccCheckDataSourceCollectionNotEmpty asserts a list data source returned at
+// least one element. Used for account-global reads (devices, locations) where no
+// fixture can be created.
+func testAccCheckDataSourceCollectionNotEmpty(dataSourceName, collection string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[dataSourceName]
+		if !ok {
+			return fmt.Errorf("data source %s not found", dataSourceName)
+		}
+
+		if count := rs.Primary.Attributes[collection+".#"]; count == "" || count == "0" {
+			return fmt.Errorf("%s returned no %s entries", dataSourceName, collection)
+		}
+
+		return nil
+	}
+}
+
+// testAccCheckDataSourceElemFieldsNonEmpty asserts that at least one element of a
+// collection has a meaningful value for every named field. Used for account-global
+// reads where exact values are not ours to control but the flattened shape must
+// still be validated.
+//
+// A numeric zero counts as unset: an unpopulated int renders as "0" in flatmap state,
+// and none of the fields this is used on (ids, viewport dimensions) are legitimately 0.
+func testAccCheckDataSourceElemFieldsNonEmpty(dataSourceName, collection string, fields ...string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[dataSourceName]
+		if !ok {
+			return fmt.Errorf("data source %s not found", dataSourceName)
+		}
+
+		if count := rs.Primary.Attributes[collection+".#"]; count == "" || count == "0" {
+			return fmt.Errorf("%s returned no %s entries", dataSourceName, collection)
+		}
+
+		for index := range testAccDataSourceCollectionIndexes(rs.Primary.Attributes, collection) {
+			complete := true
+			for _, field := range fields {
+				value := rs.Primary.Attributes[fmt.Sprintf("%s.%s.%s", collection, index, field)]
+				if value == "" || value == "0" {
+					complete = false
+					break
+				}
+			}
+			if complete {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("%s had no %s element with all of %v set to a non-empty value", dataSourceName, collection, fields)
+	}
+}
+
+func TestUniquePrivateLocationIDIsValid(t *testing.T) {
+	id := testAccUniquePrivateLocationID("acc")
+	if !privateLocationIDPattern.MatchString(id) {
+		t.Fatalf("generated private location id %q does not satisfy %s", id, privateLocationIDPattern)
+	}
+}

--- a/synthetics/data_source_variable_v2_test.go
+++ b/synthetics/data_source_variable_v2_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	sc2 "github.com/splunk/syntheticsclient/v2/syntheticsclientv2"
 )
 
 // The fixture is deliberately secret = false. Asserting the returned `value` is only
@@ -57,6 +58,12 @@ func TestAccDataSourceVariableV2(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
+		CheckDestroy: testAccCheckFixturesDestroyed(map[string]func(string) (*sc2.RequestDetails, error){
+			"synthetics_create_variable_v2": testAccIntLookup(func(id int) (*sc2.RequestDetails, error) {
+				_, details, err := testAccProvider.Meta().(*sc2.Client).GetVariableV2(id)
+				return details, err
+			}),
+		}),
 		Steps: []resource.TestStep{
 			{
 				Config: providerConfig + testAccDataSourceVariableV2Config(name),

--- a/synthetics/data_source_variable_v2_test.go
+++ b/synthetics/data_source_variable_v2_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Splunk, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package synthetics
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+// The fixture is deliberately secret = false. Asserting the returned `value` is only
+// acceptable because this is a non-secret variable holding a non-sensitive literal.
+func testAccDataSourceVariableV2Config(name string) string {
+	return fmt.Sprintf(`
+resource "synthetics_create_variable_v2" "variable_v2_datasource_fixture" {
+  provider = synthetics.synthetics
+  variable {
+    name        = %[1]q
+    description = "Terraform acceptance variable data source fixture"
+    value       = "datasource-fixture-value"
+    secret      = false
+  }
+}
+
+data "synthetics_variable_v2_check" "variable_v2_datasource" {
+  provider   = synthetics.synthetics
+  depends_on = [synthetics_create_variable_v2.variable_v2_datasource_fixture]
+
+  variable {
+    id = tonumber(synthetics_create_variable_v2.variable_v2_datasource_fixture.id)
+  }
+}
+
+data "synthetics_variables_v2_check" "variables_v2_datasource" {
+  provider   = synthetics.synthetics
+  depends_on = [synthetics_create_variable_v2.variable_v2_datasource_fixture]
+}
+`, name)
+}
+
+func TestAccDataSourceVariableV2(t *testing.T) {
+	name := testAccUniqueName("acceptance-terraform-variable-v2-datasource")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + testAccDataSourceVariableV2Config(name),
+				Check: resource.ComposeTestCheckFunc(
+					// Singleton read.
+					resource.TestCheckResourceAttrPair(
+						"data.synthetics_variable_v2_check.variable_v2_datasource", "id",
+						"synthetics_create_variable_v2.variable_v2_datasource_fixture", "id",
+					),
+					resource.TestCheckResourceAttr("data.synthetics_variable_v2_check.variable_v2_datasource", "variable.#", "1"),
+					resource.TestCheckResourceAttr("data.synthetics_variable_v2_check.variable_v2_datasource", "variable.0.name", name),
+					resource.TestCheckResourceAttr("data.synthetics_variable_v2_check.variable_v2_datasource", "variable.0.description", "Terraform acceptance variable data source fixture"),
+					resource.TestCheckResourceAttr("data.synthetics_variable_v2_check.variable_v2_datasource", "variable.0.value", "datasource-fixture-value"),
+					resource.TestCheckResourceAttr("data.synthetics_variable_v2_check.variable_v2_datasource", "variable.0.secret", "false"),
+
+					// List read must contain the fixture.
+					resource.TestCheckResourceAttrSet("data.synthetics_variables_v2_check.variables_v2_datasource", "id"),
+					testAccCheckDataSourceListContains(
+						"data.synthetics_variables_v2_check.variables_v2_datasource",
+						"variables", "name", name,
+					),
+				),
+			},
+		},
+	})
+}

--- a/synthetics/resource_location_v2.go
+++ b/synthetics/resource_location_v2.go
@@ -27,6 +27,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
+var privateLocationIDPattern = regexp.MustCompile(`\Aprivate-[a-z\-]*[a-z]\z`)
+
 func resourceLocationV2() *schema.Resource {
 	return &schema.Resource{
 		CreateContext: resourceLocationV2Create,
@@ -46,7 +48,7 @@ func resourceLocationV2() *schema.Resource {
 						"id": {
 							Type:         schema.TypeString,
 							Required:     true,
-							ValidateFunc: validation.StringMatch(regexp.MustCompile(`\Aprivate-[a-z\-]*[a-z]\z`), "name must start with 'private-'"),
+							ValidateFunc: validation.StringMatch(privateLocationIDPattern, "name must start with 'private-'"),
 							ForceNew:     true,
 						},
 						"label": {


### PR DESCRIPTION
Resolves [SYN-6875](https://splunk.atlassian.net/browse/SYN-6875)

----

### Before the change?

* 16 of the 19 Observability Synthetics V2 data sources had **no live acceptance coverage**. Only `synthetics_excluded_file_types_v2_check`, `synthetics_totp_variable_v2_check`, and `synthetics_totp_variables_v2_check` were exercised against the live API.
* Each uncovered data source's read and flatten path (`flatten*V2Data` / `flatten*V2Read`) was untested end-to-end, so a schema or flattening regression in a data source could ship without any test failing.
* The two existing files named after the client certificate data sources (`data_source_client_certificate_v2_test.go`, `data_source_client_certificates_v2_test.go`) contained schema-only unit tests, not acceptance tests.
* `make testacc` wrote `testacc.jsonl` into the working tree, and the file was not gitignored.

### After the change?

* **`make testacc` now runs at least one live assertion against all 19 V2 data sources**, covering the 16 previously untested ones. Legacy Rigor `synthetics_check` is out of scope per the ticket.
* Every fixture is a Terraform resource declared in the test config, so creation and destruction are fully managed by Terraform. No test depends on pre-existing account state, and no test creates anything it does not clean up.
* **Deletion is verified server-side.** Every test that creates a fixture has a `CheckDestroy` that re-reads each fixture id through the API client after Terraform destroys it and requires a 404. A `Delete` that reported success without actually removing the object would fail the test.
* All fixture names carry a `time.Now().UnixNano()` suffix so the suite is repeatable and parallel-safe against a shared org.
* `testacc.jsonl` is now gitignored.

#### New test files

| File | Data sources covered |
|---|---|
| `data_source_v2_acc_test.go` | shared helpers (no data source) |
| `data_source_apicheck_v2_test.go` | `api_v2_check` |
| `data_source_browsercheck_v2_test.go` | `browser_v2_check` |
| `data_source_httpcheck_v2_test.go` | `http_v2_check` |
| `data_source_portcheck_v2_test.go` | `port_v2_check` |
| `data_source_sslcheck_v2_test.go` | `ssl_v2_check` |
| `data_source_cacertificate_v2_test.go` | `ca_certificate_v2_check`, `ca_certificates_v2_check` |
| `data_source_variable_v2_test.go` | `variable_v2_check`, `variables_v2_check` |
| `data_source_location_v2_test.go` | `location_v2_check`, `locations_v2_check` |
| `data_source_devices_v2_test.go` | `devices_v2_check` |
| `data_source_downtimeconfiguration_v2_test.go` | `downtime_configuration_v2_check`, `downtime_configurations_v2_check` |

**Shared helpers** (`data_source_v2_acc_test.go`):
- `testAccUniqueName` — collision-resistant fixture names.
- `testAccUniquePrivateLocationID` — private location IDs are validated against `\Aprivate-[a-z\-]*[a-z]\z`, which forbids digits, so the timestamp is base-26 encoded into lowercase letters instead of the usual numeric suffix. `TestUniquePrivateLocationIDIsValid` is a unit test asserting the generator satisfies the production validator.
- `testAccCheckDataSourceListContains` — asserts a list data source's collection contains the fixture, matching on any index so the assertion is about presence rather than ordering within an org-wide collection.
- `testAccCheckDataSourceAttrsAbsent` — asserts named attributes appear nowhere in a data source's state at any nesting depth. Used to prove the metadata-only client certificate reads never surface key material. Reports only the offending key name, never its value.
- `testAccCheckDataSourceCollectionNotEmpty` / `testAccCheckDataSourceElemFieldsNonEmpty` — for account-global reads where exact values are not ours to control but the flattened shape must still be validated.
- `testAccCheckFixturesDestroyed` — a `CheckDestroy` built from a map of resource type to API getter. It walks the pre-destroy state and requires a 404 for every fixture id. The client reports a missing object as a 404 in `RequestDetails` **and** a non-nil error, so the helper checks status before error; `testAccIntLookup` adapts the integer-keyed getters to the string state id. `TestCheckFixturesDestroyed` is a unit test pinning that ordering along with the still-exists and unexpected-error paths, which a passing live run cannot exercise.

**Destroy verification per test.** `CheckDestroy` is wired to the matching getter for each family: `GetApiCheckV2`, `GetBrowserCheckV2`, `GetHttpCheckV2`, `GetPortCheckV2`, `GetSslCheckV2`, `GetCaCertificateV2`, `GetVariableV2`, `GetLocationV2` (string-keyed, so not wrapped in `testAccIntLookup`), and `GetDowntimeConfigurationV2`. The downtime configuration test creates two fixtures and verifies both. The client certificate test reuses the repo's existing `testAccCheckClientCertificateV2Destroy`. The devices and excluded file types tests create nothing, so they have no `CheckDestroy`.

**Per-data-source coverage.** Each singleton test creates a fixture resource, reads it back through the data source in the same config, and asserts the data source `id` matches the fixture `id` via `TestCheckResourceAttrPair` plus the representative fields the config controls. Each companion list test asserts the fixture appears in the returned collection. Where a field is populated by the API rather than by config (for example a check's `type`), the test asserts it is set rather than pinning a value.

Reads that cannot use a fixture are handled per the ticket's guidance:
- **Location** — uses a disposable private location rather than assuming any particular public location exists. The list read additionally asserts `default_location_ids` is present.
- **Devices** — the device catalog is account-global and cannot be created by Terraform, so the test asserts the collection is non-empty and that a representative element has non-empty `id`, `label`, `user_agent`, `viewport_height`, and `viewport_width`.

**Security-sensitive assertions:**
- Client certificate singleton and list reads assert metadata only — `name`, `description`, `domain`, and that `expires_at` is set — and positively assert that `public_key`, `private_key`, `content`, and `password` are absent from state. No assertion or failure message interpolates certificate or key content.
- CA certificate reads assert `name`, `description`, `file_extension`, and `filename`; list containment is matched by name. `content` is never asserted.
- The variable fixture is deliberately `secret = false` and holds a non-sensitive literal, which is the only reason asserting the returned `value` is acceptable.

#### Changes to existing tests

* `data_source_client_certificate_v2_test.go` — appended `TestAccDataSourceClientCertificateV2`. The existing schema-only unit test `TestClientCertificateV2DataSourceIsMetadataOnly` is unchanged. The new test reuses the existing `testAccClientCertificateV2Material` and `testAccClientCertificateV2Config` helpers rather than generating new certificate material.
* No existing test assertions were modified, weakened, or removed.

#### Non-test change

* `synthetics/resource_location_v2.go` — the inline private-location ID validator regex was extracted into a package-level `privateLocationIDPattern` var. Behavior is identical; this lets the ID generator's unit test assert against the production constraint instead of a duplicated copy that could silently drift.
* `.gitignore` — added `testacc.jsonl`.

#### Docs

No docs changes needed. This PR adds test coverage only; no resource or data source schema, field, or behavior changed.

### Pull request checklist
- [x] Acceptance Tests have been updated, run (`make testacc`), and pasted in this PR (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

#### Acceptance Test Output

**Full suite — `make testacc`: 126 passed, 0 failed, 2 skipped.** The two skips are pre-existing legacy Rigor V1 tests that skip themselves because `monitoring-api.rigor.com` no longer resolves; they are unrelated to this change and V1 is out of scope for this ticket.

New data source tests:

```
--- PASS: TestAccDataSourceApiCheckV2 (4.32s)
--- PASS: TestAccDataSourceBrowserCheckV2 (3.57s)
--- PASS: TestAccDataSourceCaCertificateV2 (2.57s)
--- PASS: TestAccDataSourceClientCertificateV2 (2.73s)
--- PASS: TestAccDataSourceDevicesV2 (1.65s)
--- PASS: TestAccDataSourceDowntimeConfigurationV2 (3.79s)
--- PASS: TestAccDataSourceExcludedFileTypesV2 (2.14s)
--- PASS: TestAccDataSourceHttpCheckV2 (2.76s)
--- PASS: TestAccDataSourceLocationV2 (2.77s)
--- PASS: TestAccDataSourcePortCheckV2 (2.72s)
--- PASS: TestAccDataSourceSslCheckV2 (2.77s)
--- PASS: TestAccDataSourceVariableV2 (2.70s)
```

Destroy-check unit test:

```
--- PASS: TestCheckFixturesDestroyed (0.00s)
    --- PASS: TestCheckFixturesDestroyed/deleted_fixture_passes_even_though_the_client_also_returns_an_error (0.00s)
    --- PASS: TestCheckFixturesDestroyed/surviving_fixture_fails (0.00s)
    --- PASS: TestCheckFixturesDestroyed/unexpected_error_fails (0.00s)
    --- PASS: TestCheckFixturesDestroyed/unmapped_resource_types_are_ignored (0.00s)
```

Existing acceptance tests — no regressions:

```
--- PASS: TestAccBrowserCheckV2WithTotpVariableReference (2.52s)
--- PASS: TestAccClientCertificateV2Attachments (4.12s)
--- PASS: TestAccCreateDowntimeConfigurationV2 (2.91s)
--- PASS: TestAccCreateLocationV2 (1.89s)
--- PASS: TestAccCreateRecurringDowntimeConfigurationV2 (2.84s)
--- PASS: TestAccCreateTotpVariableV2 (3.21s)
--- PASS: TestAccCreateUpdateApiCheckV2 (3.48s)
--- PASS: TestAccCreateUpdateBrowserCheckV2 (9.47s)
--- PASS: TestAccCreateUpdateBrowserCheckV2MaxWaitTime (11.40s)
--- PASS: TestAccCreateUpdateBrowserCheckV2WaitForNav (22.88s)
--- PASS: TestAccCreateUpdateCaCertificateV2 (3.44s)
--- PASS: TestAccCreateUpdateClientCertificateV2 (3.67s)
--- PASS: TestAccCreateUpdateHttpCheckV2 (7.73s)
--- PASS: TestAccCreateUpdatePortCheckV2 (3.29s)
--- PASS: TestAccCreateUpdateSslCheckV2 (3.36s)
--- PASS: TestAccCreateUpdateVariableV2 (3.49s)
--- PASS: TestAccTotpVariableV2DataSources (2.48s)
--- SKIP: TestAccBrowserCheckBasic (0.00s)
--- SKIP: TestAccHttpCheckBasic (0.00s)
PASS
ok  	github.com/splunk/terraform-provider-synthetics/synthetics	127.157s
```

#### How this was validated

1. **`go vet ./...`, `gofmt`, and `go test ./...`** (unit tests, no live calls) — all clean.
2. **Full live suite `make testacc`** — 126 passed / 0 failed / 2 pre-existing skips, 127s, output above. Run with a cleared `go` test cache so every result is a real live execution.
3. **Cleanup verified server-side, not inferred:** every fixture is re-read through the API client after destroy and must return a 404. Because fixture names are unique per run, a leaked resource would *not* collide on a subsequent run, so repeat runs alone cannot prove cleanup — the `CheckDestroy` assertions are what establish it. All 10 fixture-creating tests pass with those checks active.
4. **The destroy checks were confirmed capable of failing.** With a lookup deliberately returning a `200` instead of a `404`, the corresponding test fails as expected, so a passing result reflects a real API-side 404 rather than a check that can never fire. `TestCheckFixturesDestroyed` covers the same failure paths deterministically and without live calls.
5. **Repeatability:** the data source suite was additionally run twice back-to-back against the same live org, passing both times — confirming the unique-name scheme allows repeated and parallel runs.
6. **Coverage confirmed per data source** rather than by eye: each of the 16 data sources was verified to be both declared in a test config and referenced by at least one assertion in a test that passed.
7. **Secret hygiene confirmed against the run logs:** greps for `BEGIN CERTIFICATE`, `BEGIN … PRIVATE KEY`, `X-Sf-Token`, and the literal token value all returned zero matches in both the acceptance run logs and `testacc.jsonl`. The client certificate tests also assert absence of key material in Terraform state directly, so this is enforced by the tests and not only by log inspection.
8. **No stray artifacts** left in the working tree after the runs.

### Does this introduce a breaking change?

- [ ] Yes
- [x] No

----
